### PR TITLE
Upgrade kotlin 1.4.10 -> 1.4.21 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
    id("org.jetbrains.kotlin.plugin.serialization") version Libs.kotlinVersion
    id("maven-publish")
    signing
-   id("org.jetbrains.dokka") version Libs.kotlinVersion
+   id("org.jetbrains.dokka") version Libs.dokkaVersion
    id("io.kotest") version Libs.kotestGradlePlugin
 }
 
@@ -51,6 +51,7 @@ dependencies {
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
    kotlinOptions.jvmTarget = "1.8"
    kotlinOptions.apiVersion = "1.3"
+   kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
 }
 
 val signingKey: String? by project

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -1,6 +1,7 @@
 object Libs {
 
-   const val kotlinVersion = "1.4.10"
+   const val kotlinVersion = "1.4.21"
+   const val dokkaVersion = "1.4.20"
    const val kotestGradlePlugin = "0.2.6"
 
    object Kotest {
@@ -22,7 +23,7 @@ object Libs {
    }
 
    object Avro {
-      private const val version = "1.10.0"
+      private const val version = "1.10.1"
       const val avro = "org.apache.avro:avro:$version"
    }
 }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/Avro.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/Avro.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.github.avrokotlin.avro4k
 
 import com.github.avrokotlin.avro4k.decoder.RootRecordDecoder
@@ -40,7 +42,6 @@ open class AvroInputStreamBuilder<T>(
     */
    var decodeFormat : AvroDecodeFormat = defaultDecodeFormat
    @Deprecated("please use decodeFormat to specify the format")
-   @Suppress("DEPRECATION")
    var format: AvroFormat = AvroFormat.DataFormat
    @Deprecated("please use decodeFormat to specify the format")
    var writerSchema: Schema? = null
@@ -51,16 +52,15 @@ open class AvroInputStreamBuilder<T>(
       val defaultDecodeFormat = AvroDecodeFormat.Data(null, null)
    }
 
-   @Suppress("DEPRECATION")
    private val derivedDecodeFormat : AvroDecodeFormat
       get() {
          return when(format){
             is AvroFormat.JsonFormat -> {
-               val wschema = writerSchema ?: throw IllegalArgumentException("Writer schema needs to be supplied for Json format")
+               val wschema = writerSchema ?: error("Writer schema needs to be supplied for Json format")
                AvroDecodeFormat.Json(wschema, readerSchema?:wschema)
             }
             is AvroFormat.BinaryFormat -> {
-               val wschema = writerSchema ?: throw IllegalArgumentException("Writer schema needs to be supplied for Binary format")
+               val wschema = writerSchema ?: error("Writer schema needs to be supplied for Binary format")
                AvroDecodeFormat.Binary(wschema, readerSchema?:wschema)
             }
             is AvroFormat.DataFormat ->  AvroDecodeFormat.Data(writerSchema, readerSchema)
@@ -97,7 +97,6 @@ class AvroOutputStreamBuilder<T>(private val serializer: SerializationStrategy<T
 ){
    var encodeFormat : AvroEncodeFormat = defaultEncodeFormat
    @Deprecated("please use AvroEncodeFormat to specify the format")
-   @Suppress("DEPRECATION")
    var format: AvroFormat = AvroFormat.DataFormat
    var schema: Schema? = null
    @Deprecated("please use AvroEncodeFormat to specify the format")
@@ -106,7 +105,6 @@ class AvroOutputStreamBuilder<T>(private val serializer: SerializationStrategy<T
    companion object {
       val defaultEncodeFormat = AvroEncodeFormat.Data()
    }
-   @Suppress("DEPRECATION")
    private val derivedEncodeFormat : AvroEncodeFormat
       get() = when(format){
          AvroFormat.JsonFormat -> AvroEncodeFormat.Json

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/UserDefinedSerializerTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/UserDefinedSerializerTest.kt
@@ -6,6 +6,7 @@ import com.github.avrokotlin.avro4k.encoder.ExtendedEncoder
 import com.github.avrokotlin.avro4k.serializer.AvroSerializer
 import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.FunSpec
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -19,6 +20,7 @@ class UserDefinedSerializerTest : FunSpec({
    test("schema from user-defined-serializer") {
 
       @Serializer(forClass = String::class)
+      @OptIn(ExperimentalSerializationApi::class)
       class StringAsFixedSerializer : AvroSerializer<String>() {
 
          override fun encodeAvroValue(schema: Schema, encoder: ExtendedEncoder, obj: String) {


### PR DESCRIPTION
Updated kotlin to latest and avro minor version bump. 

Also there were some compiler warnings that bothered me. Probably nothing major but added compiler argument for that kotlin OptIn and changed Arvo class to use file suppression to fix import warning. Or now the build is free from warnings and allWarningsAsErrors kotlin option could be used.

I wonder why that dependency-bot doesn't automatically upgrade these? 