### PR TITLE
Use UUIDSerializer as contextual in Avro.default

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/Avro.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/Avro.kt
@@ -10,6 +10,7 @@ import com.github.avrokotlin.avro4k.serializer.UUIDSerializer
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 import org.apache.avro.Schema
 import org.apache.avro.file.CodecFactory
 import org.apache.avro.generic.GenericRecord
@@ -18,7 +19,6 @@ import java.nio.ByteBuffer
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.*
 
 open class AvroInputStreamBuilder<T>(
    private val converter: (Any) -> T
@@ -125,9 +125,7 @@ class Avro(
    constructor(configuration: AvroConfiguration) : this(defaultModule, configuration)
    companion object {
       val defaultModule = SerializersModule {
-         mapOf(
-            UUID::class to UUIDSerializer()
-         )
+         contextual(UUIDSerializer())
       }
       val default = Avro(defaultModule)
 

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/DefaultAvroTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/DefaultAvroTest.kt
@@ -1,0 +1,20 @@
+package com.github.avrokotlin.avro4k
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+class DefaultAvroTest : FunSpec({
+
+    test("encoding UUID") {
+
+        @Serializable
+        data class Foo(@Contextual val a: UUID)
+
+        val uuid = UUID.randomUUID()
+        val record = Avro.default.toRecord(Foo.serializer(), Foo(uuid))
+        record.get("a").toString() shouldBe uuid.toString()
+    }
+})


### PR DESCRIPTION
Current code in SerializersModule is no op:

```kotlin
 mapOf(
            UUID::class to UUIDSerializer()
         )
```