### PR TITLE
If an optional field is missing from a previoius schema, do not blow up.

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/RecordDecoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/RecordDecoder.kt
@@ -70,7 +70,12 @@ class RecordDecoder(
       }
    }
 
-   private fun fieldValue(): Any? = record[resolvedFieldName()]
+   private fun fieldValue(): Any? {
+      if (record.hasField(resolvedFieldName())) {
+         return record.get(resolvedFieldName())
+      }
+      return null
+   }
 
    private fun resolvedFieldName(): String = configuration.namingStrategy.to(FieldNaming(desc, currentIndex).name())
 


### PR DESCRIPTION
Avro introduced a change here https://issues.apache.org/jira/browse/AVRO-2278 that changes the way get works. This breaks backwards compattible schema evolution. Previously if you tried to get an optional field that did not exist on the schema, you just got null. Now it throws an exception