### PR TITLE
Polymorphic open support

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
@@ -3,6 +3,7 @@ package com.github.avrokotlin.avro4k
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.SerialKind
@@ -34,7 +35,7 @@ fun SerialDescriptor.explicitlyNamedSubclassesFrom(serializersModule: Serializer
          }
 
          override fun <Base : Any> polymorphicDefault(baseClass: KClass<Base>, defaultSerializerProvider: (className: String?) -> DeserializationStrategy<out Base>?) {
-            TODO("Figure out how default should work")
+            throw SerializationException("Polymorphic defaults are not supported in avro4k. Error whilst describing: ${capturedKClass?.simpleName}")
          }
       }
       serializersModule.dumpTo(collector)

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
@@ -1,15 +1,44 @@
 package com.github.avrokotlin.avro4k
 
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.descriptors.capturedKClass
 import kotlinx.serialization.descriptors.elementDescriptors
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.SerializersModuleCollector
+import kotlin.reflect.KClass
 
 @ExperimentalSerializationApi
 fun SerialDescriptor.leavesOfSealedClasses() : List<SerialDescriptor> {
    return if (this.kind == PolymorphicKind.SEALED) {
       elementDescriptors.filter {it.kind == SerialKind.CONTEXTUAL }.flatMap { it.elementDescriptors }.flatMap { it.leavesOfSealedClasses() }
+   } else {
+      listOf(this)
+   }
+}
+
+@ExperimentalSerializationApi
+fun SerialDescriptor.explicitlyNamedSubclassesFrom(serializersModule: SerializersModule): List<SerialDescriptor> {
+   return if (this.kind == PolymorphicKind.OPEN) {
+      val captured = mutableListOf<Pair<KClass<*>, KSerializer<*>>>()
+      val collector = object : SerializersModuleCollector {
+         override fun <T : Any> contextual(kClass: KClass<T>, provider: (typeArgumentsSerializers: List<KSerializer<*>>) -> KSerializer<*>) {
+         }
+
+         override fun <Base : Any, Sub : Base> polymorphic(baseClass: KClass<Base>, actualClass: KClass<Sub>, actualSerializer: KSerializer<Sub>) {
+            captured.add(baseClass to actualSerializer)
+         }
+
+         override fun <Base : Any> polymorphicDefault(baseClass: KClass<Base>, defaultSerializerProvider: (className: String?) -> DeserializationStrategy<out Base>?) {
+            TODO("Figure out how default should work")
+         }
+      }
+      serializersModule.dumpTo(collector)
+      captured.filter { it.first == this.capturedKClass }.map { it.second.descriptor }.sortedBy { it.serialName }
    } else {
       listOf(this)
    }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/PolymorphicClassDecoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/PolymorphicClassDecoder.kt
@@ -1,0 +1,58 @@
+package com.github.avrokotlin.avro4k.decoder
+
+import com.github.avrokotlin.avro4k.AvroConfiguration
+import com.github.avrokotlin.avro4k.RecordNaming
+import com.github.avrokotlin.avro4k.explicitlyNamedSubclassesFrom
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.AbstractDecoder
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.modules.SerializersModule
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+
+@ExperimentalSerializationApi
+class PolymorphicClassDecoder (descriptor: SerialDescriptor,
+                               private val value: GenericRecord,
+                               override val serializersModule: SerializersModule,
+                               private  val configuration: AvroConfiguration
+) : AbstractDecoder(), FieldDecoder
+{
+   private enum class DecoderState(val index : Int){
+      BEFORE(0),
+      READ_CLASS_NAME(1),
+      READ_DONE(CompositeDecoder.DECODE_DONE);
+      fun next() = values().firstOrNull{ it.ordinal > this.ordinal }?:READ_DONE
+   }
+   private var currentState = DecoderState.BEFORE
+
+   var leafDescriptor : SerialDescriptor = descriptor.explicitlyNamedSubclassesFrom(serializersModule).firstOrNull {
+      val schemaName = RecordNaming(value.schema.fullName, emptyList())
+      val serialName = RecordNaming(it)
+      serialName == schemaName
+   }?:throw SerializationException("Cannot find a subtype of ${descriptor.serialName} that can be used to deserialize a record of schema ${value.schema}.")
+
+   override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+      val currentIndex = currentState.index
+      currentState = currentState.next()
+      return currentIndex
+   }
+
+   override fun fieldSchema(): Schema = value.schema
+
+   /**
+    * Decode string needs to return the class name of the actual decoded class.
+    */
+   override fun decodeString(): String {
+      return leafDescriptor.serialName
+   }
+
+   override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
+      val recordDecoder = RootRecordDecoder(value, serializersModule, configuration)
+      return recordDecoder.decodeSerializableValue(deserializer)
+   }
+
+   override fun decodeAny(): Any? = UnsupportedOperationException()
+}

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/RecordDecoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/RecordDecoder.kt
@@ -66,6 +66,7 @@ class RecordDecoder(
             decoder
          }
          PolymorphicKind.SEALED -> SealedClassDecoder(descriptor,value as GenericRecord, serializersModule, configuration)
+         PolymorphicKind.OPEN -> PolymorphicClassDecoder(descriptor, value as GenericRecord, serializersModule, configuration)
          else -> throw UnsupportedOperationException("Decoding descriptor of kind ${descriptor.kind} is currently not supported")
       }
    }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/PolymorphicClassEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/PolymorphicClassEncoder.kt
@@ -1,0 +1,23 @@
+package com.github.avrokotlin.avro4k.encoder
+
+import com.github.avrokotlin.avro4k.Record
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.AbstractEncoder
+import kotlinx.serialization.modules.SerializersModule
+import org.apache.avro.Schema
+
+@ExperimentalSerializationApi
+class PolymorphicClassEncoder(private val schema: Schema,
+                              override val serializersModule: SerializersModule,
+                              private val callback: (Record) -> Unit): AbstractEncoder() {
+   override fun encodeString(value: String){
+      //No need to encode the string of the concrete type. This will be handled by the UnionEncoder
+   }
+
+   override fun <T : Any?> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T){
+      return UnionEncoder(schema, serializersModule, callback).encodeSerializableValue(serializer, value)
+   }
+   override fun endStructure(descriptor: SerialDescriptor) {}
+}

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/RecordEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/RecordEncoder.kt
@@ -31,6 +31,7 @@ interface StructureEncoder : FieldEncoder {
          StructureKind.CLASS -> RecordEncoder(fieldSchema(), serializersModule) { addValue(it) }
          StructureKind.MAP -> MapEncoder(fieldSchema(), serializersModule) { addValue(it) }
          PolymorphicKind.SEALED -> SealedClassEncoder(fieldSchema(), serializersModule) { addValue(it) }
+         PolymorphicKind.OPEN -> PolymorphicClassEncoder(fieldSchema(), serializersModule) { addValue(it) }
          else -> throw SerializationException(".beginStructure was called on a non-structure type [$descriptor]")
       }
    }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/schema/PolymorphicClassSchemaFor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/schema/PolymorphicClassSchemaFor.kt
@@ -1,0 +1,22 @@
+package com.github.avrokotlin.avro4k.schema
+
+import com.github.avrokotlin.avro4k.RecordNaming
+import com.github.avrokotlin.avro4k.explicitlyNamedSubclassesFrom
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.modules.SerializersModule
+import org.apache.avro.Schema
+
+@ExperimentalSerializationApi
+class PolymorphicClassSchemaFor(private val descriptor: SerialDescriptor,
+                                private val namingStrategy: NamingStrategy,
+                                private val serializersModule: SerializersModule,
+                                private val resolvedSchemas: MutableMap<RecordNaming, Schema>
+) : SchemaFor {
+   override fun schema(): Schema {
+      val subclasses = descriptor.explicitlyNamedSubclassesFrom(serializersModule)
+      return Schema.createUnion(
+         subclasses.map { ClassSchemaFor(it,namingStrategy,serializersModule, resolvedSchemas).schema() }
+      )
+   }
+}

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/schema/SchemaFor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/schema/SchemaFor.kt
@@ -197,6 +197,7 @@ fun schemaFor(serializersModule: SerializersModule,
             resolvedSchemas
          )
          PolymorphicKind.SEALED -> SealedClassSchemaFor(descriptor, namingStrategy, serializersModule, resolvedSchemas)
+         PolymorphicKind.OPEN -> PolymorphicClassSchemaFor(descriptor, namingStrategy, serializersModule, resolvedSchemas)
          StructureKind.CLASS, StructureKind.OBJECT -> when (descriptor.serialName) {
             "kotlin.Pair" -> PairSchemaFor(descriptor, namingStrategy, serializersModule, resolvedSchemas)
             else -> ClassSchemaFor(descriptor, namingStrategy, serializersModule, resolvedSchemas)

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/io/PolymorphicClassIoTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/io/PolymorphicClassIoTest.kt
@@ -1,0 +1,30 @@
+package com.github.avrokotlin.avro4k.io
+
+import com.github.avrokotlin.avro4k.Avro
+import com.github.avrokotlin.avro4k.schema.ReferencingPolymorphicRoot
+import com.github.avrokotlin.avro4k.schema.UnsealedChildOne
+import com.github.avrokotlin.avro4k.schema.UnsealedChildTwo
+import com.github.avrokotlin.avro4k.schema.UnsealedPolymorphicRoot
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import org.apache.avro.generic.GenericRecord
+
+class PolymorphicClassIoTest : StringSpec({
+   "read / write nested polymorphic class" {
+      val module = SerializersModule {
+         polymorphic(UnsealedPolymorphicRoot::class) {
+            subclass(UnsealedChildOne::class)
+            subclass(UnsealedChildTwo::class)
+         }
+      }
+      val avro = Avro(serializersModule = module)
+      writeRead(ReferencingPolymorphicRoot(UnsealedChildOne("one")), ReferencingPolymorphicRoot.serializer(), avro)
+      writeRead(ReferencingPolymorphicRoot(UnsealedChildOne("one")), ReferencingPolymorphicRoot.serializer(), avro) {
+         val root = it["root"] as GenericRecord
+         root.schema shouldBe avro.schema(UnsealedChildOne.serializer())
+      }
+   }
+})

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/io/StreamTests.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/io/StreamTests.kt
@@ -11,75 +11,75 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.avro.io.DecoderFactory
 import java.io.ByteArrayOutputStream
 
-fun <T> writeRead(t: T, serializer: KSerializer<T>) {
-   writeData(t, serializer).apply {
-      val record = readData(this, serializer)
-      val tt = Avro.default.fromRecord(serializer, record)
+fun <T> writeRead(t: T, serializer: KSerializer<T>, avro: Avro = Avro.default) {
+   writeData(t, serializer, avro).apply {
+      val record = readData(this, serializer, avro)
+      val tt = avro.fromRecord(serializer, record)
       t shouldBe tt
    }
-   writeBinary(t, serializer).apply {
-      val record = readBinary(this, serializer)
-      val tt = Avro.default.fromRecord(serializer, record)
+   writeBinary(t, serializer, avro).apply {
+      val record = readBinary(this, serializer, avro)
+      val tt = avro.fromRecord(serializer, record)
       t shouldBe tt
    }
-   writeJson(t, serializer).apply {
-      val record = readJson(this, serializer)
-      val tt = Avro.default.fromRecord(serializer, record)
+   writeJson(t, serializer, avro).apply {
+      val record = readJson(this, serializer, avro)
+      val tt = avro.fromRecord(serializer, record)
       t shouldBe tt
    }
 }
 
-fun <T> writeRead(t: T, expected: T, serializer: KSerializer<T>) {
-   writeData(t, serializer).apply {
-      val record = readData(this, serializer)
-      val tt = Avro.default.fromRecord(serializer, record)
+fun <T> writeRead(t: T, expected: T, serializer: KSerializer<T>, avro: Avro = Avro.default) {
+   writeData(t, serializer, avro).apply {
+      val record = readData(this, serializer, avro)
+      val tt = avro.fromRecord(serializer, record)
       tt shouldBe expected
    }
-   writeBinary(t, serializer).apply {
-      val record = readBinary(this, serializer)
-      val tt = Avro.default.fromRecord(serializer, record)
+   writeBinary(t, serializer, avro).apply {
+      val record = readBinary(this, serializer, avro)
+      val tt = avro.fromRecord(serializer, record)
       tt shouldBe expected
    }
 }
 
-fun <T> writeRead(t: T, serializer: KSerializer<T>, test: (GenericRecord) -> Any) {
-   writeData(t, serializer).apply {
-      val record = readData(this, serializer)
+fun <T> writeRead(t: T, serializer: KSerializer<T>, avro: Avro = Avro.default, test: (GenericRecord) -> Any) {
+   writeData(t, serializer, avro).apply {
+      val record = readData(this, serializer, avro)
       test(record)
    }
-   writeBinary(t, serializer).apply {
-      val record = readBinary(this, serializer)
+   writeBinary(t, serializer, avro).apply {
+      val record = readBinary(this, serializer, avro)
       test(record)
    }
-   writeJson(t, serializer).apply {
-      val record = readJson(this, serializer)
+   writeJson(t, serializer, avro).apply {
+      val record = readJson(this, serializer, avro)
       test(record)
    }
 }
 
-fun <T> writeData(t: T, serializer: SerializationStrategy<T>): ByteArray {
-   val schema = Avro.default.schema(serializer)
+fun <T> writeData(t: T, serializer: SerializationStrategy<T>, avro: Avro = Avro.default): ByteArray {
+   val schema = avro.schema(serializer)
    val out = ByteArrayOutputStream()
-   val avro = Avro.default.openOutputStream(serializer) {
+   val output = avro.openOutputStream(serializer) {
       encodeFormat = AvroEncodeFormat.Data()
       this.schema = schema
    }.to(out)
-   avro.write(t)
-   avro.close()
+   output.write(t)
+   output.close()
    return out.toByteArray()
 }
 
-fun <T> readJson(bytes: ByteArray, serializer: KSerializer<T>): GenericRecord {
-   val schema = Avro.default.schema(serializer)
+fun <T> readJson(bytes: ByteArray, serializer: KSerializer<T>, avro: Avro = Avro.default): GenericRecord {
+   val schema = avro.schema(serializer)
    val datumReader = GenericDatumReader<GenericRecord>(schema)
    val decoder = DecoderFactory.get().jsonDecoder(schema, SeekableByteArrayInput(bytes))
    return datumReader.read(null, decoder)
 }
 
-fun <T> writeJson(t: T, serializer: KSerializer<T>): ByteArray {
-   val schema = Avro.default.schema(serializer)
+fun <T> writeJson(t: T, serializer: KSerializer<T>, avro: Avro = Avro.default): ByteArray {
+   val schema = avro.schema(serializer)
    val baos = ByteArrayOutputStream()
-   val output = Avro.default.openOutputStream(serializer) {
+   val output = avro.openOutputStream(serializer) {
       encodeFormat = AvroEncodeFormat.Json
       this.schema = schema
    }.to(baos)
@@ -88,28 +88,28 @@ fun <T> writeJson(t: T, serializer: KSerializer<T>): ByteArray {
    return baos.toByteArray()
 }
 
-fun <T> readData(bytes: ByteArray, serializer: KSerializer<T>): GenericRecord {
-   val schema = Avro.default.schema(serializer)
-   val avro = Avro.default.openInputStream {
+fun <T> readData(bytes: ByteArray, serializer: KSerializer<T>, avro: Avro = Avro.default): GenericRecord {
+   val schema = avro.schema(serializer)
+   val input = avro.openInputStream {
       decodeFormat = AvroDecodeFormat.Data(schema)
    }.from(bytes)
-   return avro.next() as GenericRecord
+   return input.next() as GenericRecord
 }
 
-fun <T> writeBinary(t: T, serializer: SerializationStrategy<T>): ByteArray {
-   val schema = Avro.default.schema(serializer)
+fun <T> writeBinary(t: T, serializer: SerializationStrategy<T>, avro: Avro = Avro.default): ByteArray {
+   val schema = avro.schema(serializer)
    val out = ByteArrayOutputStream()
-   val avro = Avro.default.openOutputStream(serializer) {
+   val output = avro.openOutputStream(serializer) {
       encodeFormat = AvroEncodeFormat.Binary
       this.schema = schema
    }.to(out)
-   avro.write(t)
-   avro.close()
+   output.write(t)
+   output.close()
    return out.toByteArray()
 }
 
-fun <T> readBinary(bytes: ByteArray, serializer: KSerializer<T>): GenericRecord {
-   val schema = Avro.default.schema(serializer)
+fun <T> readBinary(bytes: ByteArray, serializer: KSerializer<T>, avro: Avro = Avro.default): GenericRecord {
+   val schema = avro.schema(serializer)
    val datumReader = GenericDatumReader<GenericRecord>(schema)
    val decoder = DecoderFactory.get().binaryDecoder(SeekableByteArrayInput(bytes), null)
    return datumReader.read(null, decoder)

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/PolymorphicClassSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/PolymorphicClassSchemaTest.kt
@@ -1,0 +1,33 @@
+package com.github.avrokotlin.avro4k.schema
+
+import com.github.avrokotlin.avro4k.Avro
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import org.apache.avro.Schema
+
+@Serializable
+abstract class UnsealedPolymorphicRoot
+
+@Serializable
+data class UnsealedChildOne(val one: String) : UnsealedPolymorphicRoot()
+
+@Serializable
+data class UnsealedChildTwo(val two: String) : UnsealedPolymorphicRoot()
+
+class PolymorphicClassSchemaTest : StringSpec({
+   "schema for polymorphic hierarchy" {
+      val module = SerializersModule {
+         polymorphic(UnsealedPolymorphicRoot::class) {
+            subclass(UnsealedChildOne::class)
+            subclass(UnsealedChildTwo::class)
+         }
+      }
+      val schema = Avro(serializersModule = module).schema(UnsealedPolymorphicRoot.serializer())
+      val expected = Schema.Parser().parse(javaClass.getResourceAsStream("/polymorphic.json"))
+      schema shouldBe expected
+   }
+})

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/PolymorphicClassSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/PolymorphicClassSchemaTest.kt
@@ -1,9 +1,16 @@
 package com.github.avrokotlin.avro4k.schema
 
 import com.github.avrokotlin.avro4k.Avro
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonTransformingSerializer
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
@@ -30,4 +37,32 @@ class PolymorphicClassSchemaTest : StringSpec({
       val expected = Schema.Parser().parse(javaClass.getResourceAsStream("/polymorphic.json"))
       schema shouldBe expected
    }
+
+   "polymorphic defaults are not supported" {
+      val module = SerializersModule {
+         polymorphic(UnsealedPolymorphicRoot::class) {
+            subclass(UnsealedChildOne::class)
+            subclass(UnsealedChildTwo::class)
+            default { TypeSerializer }
+         }
+      }
+      val exception = shouldThrow<SerializationException> {
+         Avro(serializersModule = module).schema(UnsealedPolymorphicRoot.serializer())
+      }
+      exception.message shouldBe "Polymorphic defaults are not supported in avro4k. Error whilst describing: UnsealedPolymorphicRoot"
+   }
 })
+
+object TypeSerializer : JsonTransformingSerializer<UnsealedPolymorphicRoot>(UnsealedPolymorphicRoot.serializer()) {
+   override fun transformDeserialize(element: JsonElement): JsonElement {
+      return when (element) {
+         is JsonPrimitive -> {
+            buildJsonObject {
+               put("type", element)
+            }
+         }
+         is JsonObject -> element
+         else -> throw IllegalAccessException("Unsupported json element type")
+      }
+   }
+}

--- a/src/test/resources/polymorphic.json
+++ b/src/test/resources/polymorphic.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "record",
+    "name": "UnsealedChildOne",
+    "namespace": "com.github.avrokotlin.avro4k.schema",
+    "fields": [
+      {
+        "name": "one",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "name": "UnsealedChildTwo",
+    "namespace": "com.github.avrokotlin.avro4k.schema",
+    "fields": [
+      {
+        "name": "two",
+        "type": "string"
+      }
+    ]
+  }
+]

--- a/src/test/resources/polymorphic_reference.json
+++ b/src/test/resources/polymorphic_reference.json
@@ -1,0 +1,33 @@
+{
+  "type": "record",
+  "name": "ReferencingPolymorphicRoot",
+  "namespace": "com.github.avrokotlin.avro4k.schema",
+  "fields": [
+    {
+      "name": "root",
+      "type": [
+        {
+          "type": "record",
+          "name": "UnsealedChildOne",
+          "fields": [
+            {
+              "name": "one",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "UnsealedChildTwo",
+          "fields": [
+            {
+              "name": "two",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
Huge disclaimer: I don't know kotlinx or avro4k internals at all so there's a good chance this implementation is not on the right track. It was also done under delivery time pressure so forgive me for not doing deeper homework on this. Happy to take any pointers on how to improve it.

This PR adds support for open / unsealed / abstract classes, configured like so:
```kotlin
val module = SerializersModule {
   polymorphic(UnsealedPolymorphicRoot::class) {
      subclass(UnsealedChildOne::class)
      subclass(UnsealedChildTwo::class)
   }
}
val schema = Avro(serializersModule = module).schema(UnsealedPolymorphicRoot.serializer())
```

For now it explicitly doesn't support polymorphic defaults - this is a feature someone could build on top if they want to.