### PR TITLE
DO NOT MERGE: Demonstrate failure when subclass is sealed

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/RecapturedClassSerialDescriptor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/RecapturedClassSerialDescriptor.kt
@@ -1,0 +1,31 @@
+package com.github.avrokotlin.avro4k
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlin.reflect.KClass
+
+class RecapturedClassSerialDescriptor(private val delegate: SerialDescriptor, val capturedKClass: KClass<*>): SerialDescriptor {
+    @ExperimentalSerializationApi
+    override val elementsCount = delegate.elementsCount
+
+    @ExperimentalSerializationApi
+    override val kind = delegate.kind
+
+    @ExperimentalSerializationApi
+    override val serialName = delegate.serialName
+
+    @ExperimentalSerializationApi
+    override fun getElementAnnotations(index: Int) = delegate.getElementAnnotations(index)
+
+    @ExperimentalSerializationApi
+    override fun getElementDescriptor(index: Int) = RecapturedClassSerialDescriptor(delegate.getElementDescriptor(index), capturedKClass)
+
+    @ExperimentalSerializationApi
+    override fun getElementIndex(name: String) = delegate.getElementIndex(name)
+
+    @ExperimentalSerializationApi
+    override fun getElementName(index: Int) = delegate.getElementName(index)
+
+    @ExperimentalSerializationApi
+    override fun isElementOptional(index: Int) = delegate.isElementOptional(index)
+}

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
@@ -1,8 +1,15 @@
 package com.github.avrokotlin.avro4k
 
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SealedClassSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.SerializersModuleCollector
+import kotlin.reflect.KClass
 
 @ExperimentalSerializationApi
 fun SerialDescriptor.leavesOfSealedClasses(): List<SerialDescriptor> {
@@ -14,11 +21,32 @@ fun SerialDescriptor.leavesOfSealedClasses(): List<SerialDescriptor> {
     }
 }
 
+@OptIn(InternalSerializationApi::class)
 @ExperimentalSerializationApi
 fun SerialDescriptor.possibleSerializationSubclasses(serializersModule: SerializersModule): List<SerialDescriptor> {
     return when (this.kind) {
         PolymorphicKind.SEALED -> this.leavesOfSealedClasses()
-        PolymorphicKind.OPEN -> serializersModule.getPolymorphicDescriptors(this).sortedBy { it.serialName }
+        PolymorphicKind.OPEN -> {
+            val captured = mutableListOf<Pair<KClass<*>, KSerializer<*>>>()
+            val collector = object : SerializersModuleCollector {
+                override fun <T : Any> contextual(kClass: KClass<T>, provider: (typeArgumentsSerializers: List<KSerializer<*>>) -> KSerializer<*>) {
+                }
+
+                override fun <Base : Any, Sub : Base> polymorphic(baseClass: KClass<Base>, actualClass: KClass<Sub>, actualSerializer: KSerializer<Sub>) {
+                    captured.add(baseClass to actualSerializer)
+                }
+
+                override fun <Base : Any> polymorphicDefault(baseClass: KClass<Base>, defaultSerializerProvider: (className: String?) -> DeserializationStrategy<out Base>?) {
+                    throw SerializationException("Polymorphic defaults are not supported in avro4k. Error whilst describing: ${capturedKClass?.simpleName}")
+                }
+            }
+            serializersModule.dumpTo(collector)
+            val serializers = captured.filter { it.first == this.capturedKClass }.map { it.second }
+            serializers.map { when(it) {
+                is SealedClassSerializer -> RecapturedClassSerialDescriptor(it.descriptor, it.baseClass)
+                else -> it.descriptor
+            } }.sortedBy { it.serialName }
+        }
         else -> throw UnsupportedOperationException("Can't get possible serialization subclasses for the SerialDescriptor of kind ${this.kind}.")
     }
 }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/schema/SchemaFor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/schema/SchemaFor.kt
@@ -2,6 +2,7 @@ package com.github.avrokotlin.avro4k.schema
 
 import com.github.avrokotlin.avro4k.AnnotationExtractor
 import com.github.avrokotlin.avro4k.Avro
+import com.github.avrokotlin.avro4k.RecapturedClassSerialDescriptor
 import com.github.avrokotlin.avro4k.RecordNaming
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
@@ -188,7 +189,10 @@ fun schemaFor(serializersModule: SerializersModule,
             serializersModule,
             requireNotNull(
                serializersModule.getContextualDescriptor(descriptor)
-                  ?: descriptor.capturedKClass?.serializerOrNull()?.descriptor
+                  ?: when (descriptor) {
+                     is RecapturedClassSerialDescriptor -> descriptor.capturedKClass.serializerOrNull()?.descriptor
+                     else -> descriptor.capturedKClass?.serializerOrNull()?.descriptor
+                  }
             ) {
                "Contextual or default serializer not found for $descriptor "
             },

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/PolymorphicClassSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/PolymorphicClassSchemaTest.kt
@@ -17,7 +17,9 @@ abstract class UnsealedPolymorphicRoot
 data class UnsealedChildOne(val one: String) : UnsealedPolymorphicRoot()
 
 @Serializable
-data class UnsealedChildTwo(val two: String) : UnsealedPolymorphicRoot()
+sealed class SealedChildTwo : UnsealedPolymorphicRoot()
+@Serializable
+data class UnsealedChildTwo(val two: String) : SealedChildTwo()
 
 @Serializable
 data class ReferencingPolymorphicRoot(
@@ -30,7 +32,7 @@ class PolymorphicClassSchemaTest : StringSpec({
       val module = SerializersModule {
          polymorphic(UnsealedPolymorphicRoot::class) {
             subclass(UnsealedChildOne::class)
-            subclass(UnsealedChildTwo::class)
+            subclass(SealedChildTwo::class)
          }
       }
       val schema = Avro(serializersModule = module).schema(UnsealedPolymorphicRoot.serializer())

--- a/src/test/resources/polymorphic.json
+++ b/src/test/resources/polymorphic.json
@@ -1,22 +1,37 @@
 [
   {
     "type": "record",
-    "name": "UnsealedChildOne",
+    "name": "SealedChildTwo",
     "namespace": "com.github.avrokotlin.avro4k.schema",
     "fields": [
       {
-        "name": "one",
+        "name": "type",
         "type": "string"
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "type": "record",
+            "name": "UnsealedChildTwo",
+            "fields": [
+              {
+                "name": "two",
+                "type": "string"
+              }
+            ]
+          }
+        ]
       }
     ]
   },
   {
     "type": "record",
-    "name": "UnsealedChildTwo",
+    "name": "UnsealedChildOne",
     "namespace": "com.github.avrokotlin.avro4k.schema",
     "fields": [
       {
-        "name": "two",
+        "name": "one",
         "type": "string"
       }
     ]


### PR DESCRIPTION
@thake I didn't know the easiest way to get this in front of you, but extending on our work there appears to be an important edgecase that isn't covered. Try running `PolymorphicClassSchemaTest` in this branch.

For some reason it's not capturing the kClass inside of the descriptor for `SealedChildTwo` - but I have no idea why:

```
Contextual or default serializer not found for kotlinx.serialization.Sealed<SealedChildTwo>(com.github.avrokotlin.avro4k.schema.UnsealedChildTwo: com.github.avrokotlin.avro4k.schema.UnsealedChildTwo)
java.lang.IllegalArgumentException: Contextual or default serializer not found for kotlinx.serialization.Sealed<SealedChildTwo>(com.github.avrokotlin.avro4k.schema.UnsealedChildTwo: com.github.avrokotlin.avro4k.schema.UnsealedChildTwo)
	at com.github.avrokotlin.avro4k.schema.SchemaForKt.schemaFor(SchemaFor.kt:189)
	at com.github.avrokotlin.avro4k.schema.ClassSchemaFor.buildField(ClassSchemaFor.kt:78)
	at com.github.avrokotlin.avro4k.schema.ClassSchemaFor.dataClassSchema(ClassSchemaFor.kt:63)
	at com.github.avrokotlin.avro4k.schema.ClassSchemaFor.schema(ClassSchemaFor.kt:43)
	at com.github.avrokotlin.avro4k.schema.UnionSchemaFor.schema(UnionSchemaFor.kt:19)
	at com.github.avrokotlin.avro4k.Avro.schema(Avro.kt:264)
	at com.github.avrokotlin.avro4k.Avro.schema(Avro.kt:269)
	at com.github.avrokotlin.avro4k.schema.PolymorphicClassSchemaTest$1$1.invokeSuspend(PolymorphicClassSchemaTest.kt:38)
```