### PR TITLE
DO NOT MERGE attempt to support sealed interface multiple inheritance

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
@@ -15,7 +15,7 @@ fun SerialDescriptor.possibleSerializationSubclasses(serializersModule: Serializ
             .flatMap { it.possibleSerializationSubclasses(serializersModule) }
         PolymorphicKind.OPEN -> {
             val capturedClass = this.capturedKClass
-            if (capturedClass?.isSealed == true) {
+            val descriptors = if (capturedClass?.isSealed == true) {
                 //A sealed interface will have the kind PolymorphicKind.OPEN, although it is sealed. Retrieve all the possible direct subclasses of the interface
                 capturedClass.sealedSubclasses.map { serializersModule.serializer(it.starProjectedType) }
                     .map { it.descriptor }
@@ -24,6 +24,8 @@ fun SerialDescriptor.possibleSerializationSubclasses(serializersModule: Serializ
                 serializersModule.getPolymorphicDescriptors(this)
                     .flatMap { it.possibleSerializationSubclasses(serializersModule) }
             }
+            // descriptors may exist more than once due to diamond inheritance so we need to filter duplicates out
+            descriptors.distinct()
         }
         else -> throw UnsupportedOperationException("Can't get possible serialization subclasses for the SerialDescriptor of kind ${this.kind}.")
     }

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/io/MixedPolymorphicIoTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/io/MixedPolymorphicIoTest.kt
@@ -2,6 +2,7 @@ package com.github.avrokotlin.avro4k.io
 
 import com.github.avrokotlin.avro4k.Avro
 import com.github.avrokotlin.avro4k.schema.ConstExpr
+import com.github.avrokotlin.avro4k.schema.Expr
 import com.github.avrokotlin.avro4k.schema.MultiplicationExpr
 import com.github.avrokotlin.avro4k.schema.NegateExpr
 import com.github.avrokotlin.avro4k.schema.OtherBinaryExpr
@@ -22,6 +23,10 @@ class MixedPolymorphicIoTest : StringSpec({
          }
          polymorphic(OtherBinaryExpr::class) {
             subclass(MultiplicationExpr::class)
+         }
+         // this shouldn't be necessary
+         polymorphic(Expr::class) {
+            subclass(NegateExpr::class)
          }
       }
       val avro = Avro(serializersModule = module)

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/io/MixedPolymorphicIoTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/io/MixedPolymorphicIoTest.kt
@@ -1,0 +1,35 @@
+package com.github.avrokotlin.avro4k.io
+
+import com.github.avrokotlin.avro4k.Avro
+import com.github.avrokotlin.avro4k.schema.ConstExpr
+import com.github.avrokotlin.avro4k.schema.MultiplicationExpr
+import com.github.avrokotlin.avro4k.schema.NegateExpr
+import com.github.avrokotlin.avro4k.schema.OtherBinaryExpr
+import com.github.avrokotlin.avro4k.schema.OtherUnaryExpr
+import com.github.avrokotlin.avro4k.schema.ReferencingMixedPolymorphic
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import org.apache.avro.generic.GenericRecord
+
+class MixedPolymorphicIoTest : StringSpec({
+   "read / write referencing a mixed sealed hierarchy" {
+      val module = SerializersModule {
+         polymorphic(OtherUnaryExpr::class) {
+            subclass(ConstExpr::class)
+         }
+         polymorphic(OtherBinaryExpr::class) {
+            subclass(MultiplicationExpr::class)
+         }
+      }
+      val avro = Avro(serializersModule = module)
+      writeRead(ReferencingMixedPolymorphic(NegateExpr(3)), ReferencingMixedPolymorphic.serializer(), avro)
+      writeRead(ReferencingMixedPolymorphic(NegateExpr(3)), ReferencingMixedPolymorphic.serializer(), avro) {
+         val reference = it["notNullable"] as GenericRecord
+         reference.schema shouldBe avro.schema(NegateExpr.serializer())
+         reference["value"] shouldBe 3
+      }
+   }
+})

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/MixedPolymorphicSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/MixedPolymorphicSchemaTest.kt
@@ -14,6 +14,7 @@ sealed interface Expr
 sealed interface UnaryExpr : Expr {
     val value : Int
 }
+sealed interface DiamondInheritance : Expr
 @Serializable
 sealed class BinaryExpr : Expr {
     abstract val left: Int
@@ -22,7 +23,7 @@ sealed class BinaryExpr : Expr {
 @Serializable
 object NullaryExpr : Expr
 @Serializable
-data class NegateExpr(override val value : Int) : UnaryExpr
+data class NegateExpr(override val value : Int) : UnaryExpr, DiamondInheritance
 @Serializable
 data class AddExpr(override val left : Int, override val right : Int) : BinaryExpr()
 @Serializable


### PR DESCRIPTION
@thake another weird edgecase that I encountered in our real-world application on top of Avro4k 1.5.0.

We happen to need to use multiple/diamond sealed interface inheritance in our application which confuses Avro4k:
```kotlin
Duplicate in union:com.github.avrokotlin.avro4k.schema.NegateExpr
org.apache.avro.AvroRuntimeException: Duplicate in union:com.github.avrokotlin.avro4k.schema.NegateExpr
	at org.apache.avro.Schema$UnionSchema.<init>(Schema.java:1197)
	at org.apache.avro.Schema.createUnion(Schema.java:247)
	at com.github.avrokotlin.avro4k.schema.UnionSchemaFor.schema(UnionSchemaFor.kt:20)
	at com.github.avrokotlin.avro4k.schema.ClassSchemaFor.buildField(ClassSchemaFor.kt:84)
	at com.github.avrokotlin.avro4k.schema.ClassSchemaFor.dataClassSchema(ClassSchemaFor.kt:63)
	at com.github.avrokotlin.avro4k.schema.ClassSchemaFor.schema(ClassSchemaFor.kt:43)
	at com.github.avrokotlin.avro4k.Avro.schema(Avro.kt:264)
	at com.github.avrokotlin.avro4k.Avro.schema(Avro.kt:269)
```
This is because the subtype scan finds `NegateExpr` twice, once through each branch of the diamond inheritance. As you can see in the second commit, I've tried just filtering out duplicates, but then I ran into a much more obscure error that I don't completely understand and probably need your help with:
```kotlin
Class 'NegateExpr' is not registered for polymorphic serialization in the scope of 'Expr'.
kotlinx.serialization.SerializationException: Class 'NegateExpr' is not registered for polymorphic serialization in the scope of 'Expr'.
Mark the base class as 'sealed' or register the serializer explicitly.
	at kotlinx.serialization.internal.AbstractPolymorphicSerializerKt.throwSubtypeNotRegistered(AbstractPolymorphicSerializer.kt:102)
	at kotlinx.serialization.internal.AbstractPolymorphicSerializerKt.throwSubtypeNotRegistered(AbstractPolymorphicSerializer.kt:113)
	at kotlinx.serialization.PolymorphicSerializerKt.findPolymorphicSerializer(PolymorphicSerializer.kt:96)
	at kotlinx.serialization.internal.AbstractPolymorphicSerializer.serialize(AbstractPolymorphicSerializer.kt:32)
	at kotlinx.serialization.encoding.Encoder$DefaultImpls.encodeSerializableValue(Encoding.kt:282)
	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableValue(AbstractEncoder.kt:18)
	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableElement(AbstractEncoder.kt:80)
	at com.github.avrokotlin.avro4k.schema.ReferencingMixedPolymorphic.write$Self(MixedPolymorphicSchemaTest.kt:40)
	at com.github.avrokotlin.avro4k.schema.ReferencingMixedPolymorphic$$serializer.serialize(MixedPolymorphicSchemaTest.kt:40)
	at com.github.avrokotlin.avro4k.schema.ReferencingMixedPolymorphic$$serializer.serialize(MixedPolymorphicSchemaTest.kt:40)
	at kotlinx.serialization.encoding.Encoder$DefaultImpls.encodeSerializableValue(Encoding.kt:282)
	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableValue(AbstractEncoder.kt:18)
	at com.github.avrokotlin.avro4k.Avro.toRecord(Avro.kt:240)
	at com.github.avrokotlin.avro4k.Avro$openOutputStream$builder$1$1.invoke(Avro.kt:217)
	at com.github.avrokotlin.avro4k.Avro$openOutputStream$builder$1$1.invoke(Avro.kt:217)
```
As you can see I'm able to work around this by adding an explicit mapping from the top-level base class to the diamond inheriting subclass, but this is obviously not a good solution:
```kotlin
      val module = SerializersModule {
         polymorphic(OtherUnaryExpr::class) {
            subclass(ConstExpr::class)
         }
         polymorphic(OtherBinaryExpr::class) {
            subclass(MultiplicationExpr::class)
         }
         // this shouldn't be necessary
         polymorphic(Expr::class) {
            subclass(NegateExpr::class)
         }
      }
```
Keen to see if you can find a better solution to this problem as it's beyond the limits of my `kotlinx.serialization`, `avro` and `avro4k` knowledge.