### PR TITLE
Fixing sealed interface unions

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
@@ -15,7 +15,7 @@ fun SerialDescriptor.possibleSerializationSubclasses(serializersModule: Serializ
             .flatMap { it.possibleSerializationSubclasses(serializersModule) }
         PolymorphicKind.OPEN -> {
             val capturedClass = this.capturedKClass
-            if (capturedClass?.isSealed == true) {
+            val descriptors = if (capturedClass?.isSealed == true) {
                 //A sealed interface will have the kind PolymorphicKind.OPEN, although it is sealed. Retrieve all the possible direct subclasses of the interface
                 capturedClass.sealedSubclasses.map { serializersModule.serializer(it.starProjectedType) }
                     .map { it.descriptor }
@@ -24,6 +24,8 @@ fun SerialDescriptor.possibleSerializationSubclasses(serializersModule: Serializ
                 serializersModule.getPolymorphicDescriptors(this)
                     .flatMap { it.possibleSerializationSubclasses(serializersModule) }
             }
+            // descriptors may exist more than once due to diamond inheritance so we need to filter duplicates out
+            descriptors.distinct()
         }
         else -> throw UnsupportedOperationException("Can't get possible serialization subclasses for the SerialDescriptor of kind ${this.kind}.")
     }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
@@ -1,10 +1,24 @@
+@file:Suppress("UNCHECKED_CAST")
+
 package com.github.avrokotlin.avro4k
 
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.internal.AbstractPolymorphicSerializer
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import kotlin.reflect.full.starProjectedType
+
+@OptIn(InternalSerializationApi::class)
+fun <T : Any> AbstractPolymorphicSerializer<T>.findPolymorphicSerializerInclSealedInterfaceOrNull(
+    decoder: CompositeDecoder,
+    klassName: String?
+): DeserializationStrategy<out T>? {
+    return decoder.serializersModule.getPolymorphicInclSealedInterfaces(baseClass, klassName)
+}
 
 @ExperimentalSerializationApi
 fun SerialDescriptor.possibleSerializationSubclasses(serializersModule: SerializersModule): List<SerialDescriptor> {

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/SerialDescriptor.kt
@@ -38,7 +38,7 @@ fun SerialDescriptor.possibleSerializationSubclasses(serializersModule: Serializ
                 serializersModule.getPolymorphicDescriptors(this)
                     .flatMap { it.possibleSerializationSubclasses(serializersModule) }
             }
-            // descriptors may exist more than once due to diamond inheritance so we need to filter duplicates out
+            // descriptors may exist more than once due to diamond inheritance, so we need to filter duplicates out
             descriptors.distinct()
         }
         else -> throw UnsupportedOperationException("Can't get possible serialization subclasses for the SerialDescriptor of kind ${this.kind}.")

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/SerializersModule.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/SerializersModule.kt
@@ -7,11 +7,13 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.starProjectedType
+import kotlin.reflect.full.superclasses
 
 @OptIn(ExperimentalStdlibApi::class, ExperimentalSerializationApi::class)
 fun <T : Any> SerializersModule.getPolymorphicInclSealedInterfaces(baseClass: KClass<in T>, value: T): SerializationStrategy<T> {
     //First try to get it from the module
     var result = this.getPolymorphic(baseClass, value)
+    value::class.superclasses
     if(result == null && baseClass.isSealed && value::class.isSubclassOf(baseClass)) {
         result = this.serializer(value::class.starProjectedType)
     }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/SerializersModule.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/SerializersModule.kt
@@ -1,0 +1,55 @@
+
+
+package com.github.avrokotlin.avro4k
+
+import kotlinx.serialization.*
+import kotlinx.serialization.modules.SerializersModule
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.starProjectedType
+
+@OptIn(ExperimentalStdlibApi::class, ExperimentalSerializationApi::class)
+fun <T : Any> SerializersModule.getPolymorphicInclSealedInterfaces(baseClass: KClass<in T>, value: T): SerializationStrategy<T> {
+    //First try to get it from the module
+    var result = this.getPolymorphic(baseClass, value)
+    if(result == null && baseClass.isSealed && value::class.isSubclassOf(baseClass)) {
+        result = this.serializer(value::class.starProjectedType)
+    }
+    return result ?: throwSubtypeNotRegistered(value::class, baseClass)
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+fun <T : Any> SerializersModule.getPolymorphicInclSealedInterfaces(baseClass: KClass<in T>, klassName: String?): DeserializationStrategy<out T>? {
+    var deserializer = getPolymorphic(baseClass, klassName)
+    if (deserializer == null && baseClass.isSealed) {
+        deserializer = getSealedSubclassDeserializerOrNull(baseClass, klassName)
+    }
+    return deserializer
+}
+
+@Suppress("UNCHECKED_CAST")
+fun <T : Any> SerializersModule.getSealedSubclassDeserializerOrNull(
+    baseClass: KClass<in T>,
+    klassName: String?
+): DeserializationStrategy<out T>? {
+    return baseClass.sealedSubclasses.asSequence()
+        .flatMap { if (it.isSealed) it.sealedSubclasses.asSequence() else sequenceOf(it) }
+        .filter { it.qualifiedName == klassName }.map { this.serializer(it.starProjectedType) }
+        .firstOrNull() as? KSerializer<out T>
+}
+
+
+internal fun throwSubtypeNotRegistered(subClassName: String?, baseClass: KClass<*>): Nothing {
+    val scope = "in the scope of '${baseClass.simpleName}'"
+    throw SerializationException(
+        if (subClassName == null)
+            "Class discriminator was missing and no default polymorphic serializers were registered $scope"
+        else
+            "Class '$subClassName' is not registered for polymorphic serialization $scope.\n" +
+                    "Mark the base class or implemented interface as 'sealed' or register the serializer explicitly."
+    )
+}
+
+
+internal fun throwSubtypeNotRegistered(subClass: KClass<*>, baseClass: KClass<*>): Nothing =
+    throwSubtypeNotRegistered(subClass.simpleName ?: "$subClass", baseClass)

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/AbstractAvroDecoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/AbstractAvroDecoder.kt
@@ -1,0 +1,35 @@
+package com.github.avrokotlin.avro4k.decoder
+
+import com.github.avrokotlin.avro4k.findPolymorphicSerializerInclSealedInterfaceOrNull
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.encoding.AbstractDecoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.internal.AbstractPolymorphicSerializer
+
+@OptIn(ExperimentalSerializationApi::class)
+abstract class AbstractAvroDecoder(): AbstractDecoder() {
+
+
+    @OptIn(InternalSerializationApi::class)
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
+        return if(deserializer is PolymorphicSerializer<*>) {
+            decodePolymorphicSerializableValue(deserializer)
+        } else{
+            super.decodeSerializableValue(deserializer)
+        }
+    }
+    @Suppress("UNCHECKED_CAST")
+    @OptIn(InternalSerializationApi::class)
+    fun <S : Any> decodePolymorphicSerializableValue(serializer: AbstractPolymorphicSerializer<*>) : S{
+       // Special code to support sealed interfaces encoding as they are not natively supported in kotlinx.serialization
+       this.decodeStructure(serializer.descriptor) {
+           val unionDecoder = this as UnionDecoder
+           val klassName = unionDecoder.decodeString()
+           val strategy = serializer.findPolymorphicSerializerInclSealedInterfaceOrNull(this, klassName) ?: throw IllegalStateException("No deserializer found for class name '$klassName'.")
+           return unionDecoder.decodeSerializableElement(serializer.descriptor, 1, strategy) as S
+       }
+    }
+}

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/RecordDecoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/RecordDecoder.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
-import kotlinx.serialization.encoding.AbstractDecoder
 import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.modules.SerializersModule
@@ -32,7 +31,7 @@ class RecordDecoder(
    private val record: GenericRecord,
    override val serializersModule: SerializersModule,
    private val configuration: AvroConfiguration,
-) : AbstractDecoder(), FieldDecoder {
+) : AbstractAvroDecoder(), FieldDecoder {
 
    private var currentIndex = -1
 
@@ -71,8 +70,9 @@ class RecordDecoder(
    }
 
    private fun fieldValue(): Any? {
-      if (record.hasField(resolvedFieldName())) {
-         return record.get(resolvedFieldName())
+      val resolvedFieldName = resolvedFieldName()
+      if (record.hasField(resolvedFieldName)) {
+         return record.get(resolvedFieldName)
       }
       return null
    }
@@ -158,6 +158,11 @@ class RecordDecoder(
    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
       currentIndex++
       return if (currentIndex < descriptor.elementsCount) currentIndex else CompositeDecoder.DECODE_DONE
+   }
+
+   @ExperimentalSerializationApi
+   override fun decodeSequentially(): Boolean {
+      return super.decodeSequentially()
    }
 }
 

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/RecordDecoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/RecordDecoder.kt
@@ -159,10 +159,5 @@ class RecordDecoder(
       currentIndex++
       return if (currentIndex < descriptor.elementsCount) currentIndex else CompositeDecoder.DECODE_DONE
    }
-
-   @ExperimentalSerializationApi
-   override fun decodeSequentially(): Boolean {
-      return super.decodeSequentially()
-   }
 }
 

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/AbstractAvroEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/AbstractAvroEncoder.kt
@@ -1,0 +1,31 @@
+package com.github.avrokotlin.avro4k.encoder
+
+import com.github.avrokotlin.avro4k.getPolymorphicInclSealedInterfaces
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.encoding.AbstractEncoder
+import kotlinx.serialization.encoding.encodeStructure
+import kotlinx.serialization.internal.AbstractPolymorphicSerializer
+import kotlin.reflect.KClass
+
+@Suppress("UNCHECKED_CAST")
+@OptIn(ExperimentalSerializationApi::class)
+abstract class AbstractAvroEncoder() : AbstractEncoder(){
+    @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+    override fun <T : Any?> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
+        if(serializer is AbstractPolymorphicSerializer<*> && value != null) {
+            encodePolymorphicSerializableValue(serializer, value)
+        } else{
+            super.encodeSerializableValue(serializer, value)
+        }
+    }
+    @OptIn(InternalSerializationApi::class)
+    fun <S : Any> encodePolymorphicSerializableValue(serializer: AbstractPolymorphicSerializer<*>, value : S){
+        //Special code to support sealed interfaces encoding as they are not natively supported in kotlinx.serialization
+        val actualSerializer = serializersModule.getPolymorphicInclSealedInterfaces(serializer.baseClass as KClass<in S>, value)
+        this.encodeStructure(serializer.descriptor) {
+            encodeSerializableElement(serializer.descriptor, 1, actualSerializer, value)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/ListEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/ListEncoder.kt
@@ -2,7 +2,6 @@ package com.github.avrokotlin.avro4k.encoder
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.AbstractEncoder
 import kotlinx.serialization.encoding.CompositeEncoder
 import kotlinx.serialization.modules.SerializersModule
 import org.apache.avro.Schema
@@ -13,7 +12,7 @@ import java.nio.ByteBuffer
 @ExperimentalSerializationApi
 class ListEncoder(private val schema: Schema,
                   override val serializersModule: SerializersModule,
-                  private val callback: (GenericData.Array<Any?>) -> Unit) : AbstractEncoder(), StructureEncoder {
+                  private val callback: (GenericData.Array<Any?>) -> Unit) : AbstractAvroEncoder(), StructureEncoder {
 
    private val list = mutableListOf<Any?>()
 

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/MapEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/MapEncoder.kt
@@ -4,7 +4,6 @@ package com.github.avrokotlin.avro4k.encoder
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.AbstractEncoder
 import kotlinx.serialization.encoding.CompositeEncoder
 import kotlinx.serialization.modules.SerializersModule
 import org.apache.avro.Schema
@@ -15,7 +14,7 @@ import java.nio.ByteBuffer
 @ExperimentalSerializationApi
 class MapEncoder(schema: Schema,
                  override val serializersModule: SerializersModule,
-                 private val callback: (Map<Utf8, *>) -> Unit) : AbstractEncoder(),
+                 private val callback: (Map<Utf8, *>) -> Unit) : AbstractAvroEncoder(),
    CompositeEncoder,
    StructureEncoder {
 

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/RecordEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/RecordEncoder.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
-import kotlinx.serialization.encoding.AbstractEncoder
 import kotlinx.serialization.encoding.CompositeEncoder
 import kotlinx.serialization.modules.SerializersModule
 import org.apache.avro.Schema
@@ -39,7 +38,7 @@ interface StructureEncoder : FieldEncoder {
 @ExperimentalSerializationApi
 class RecordEncoder(private val schema: Schema,
                     override val serializersModule: SerializersModule,
-                    val callback: (Record) -> Unit) : AbstractEncoder(), StructureEncoder {
+                    val callback: (Record) -> Unit) : AbstractAvroEncoder(), StructureEncoder {
 
    private val builder = RecordBuilder(schema)
    private var currentIndex = -1

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/RootRecordEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/RootRecordEncoder.kt
@@ -3,7 +3,6 @@ package com.github.avrokotlin.avro4k.encoder
 import com.github.avrokotlin.avro4k.Record
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
@@ -13,23 +12,19 @@ import kotlinx.serialization.modules.SerializersModule
 import org.apache.avro.Schema
 
 @ExperimentalSerializationApi
-class RootRecordEncoder(private val schema: Schema,
-                        override val serializersModule: SerializersModule,
-                        private val callback: (Record) -> Unit) : AbstractEncoder() {
+class RootRecordEncoder(
+    private val schema: Schema,
+    override val serializersModule: SerializersModule,
+    private val callback: (Record) -> Unit
+) : AbstractEncoder() {
 
-   override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
-      return when (descriptor.kind) {
-         is StructureKind.CLASS -> RecordEncoder(schema, serializersModule, callback)
-         is PolymorphicKind -> UnionEncoder(schema,serializersModule,callback)
-         else -> throw SerializationException("Unsupported root element passed to root record encoder")
-      }
-   }
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
+        return when (descriptor.kind) {
+            is StructureKind.CLASS -> RecordEncoder(schema, serializersModule, callback)
+            is PolymorphicKind -> UnionEncoder(schema, serializersModule, callback)
+            else -> throw SerializationException("Unsupported root element passed to root record encoder")
+        }
+    }
 
-   override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
-      super.encodeSerializableValue(serializer, value)
-   }
-
-   override fun endStructure(descriptor: SerialDescriptor) {
-
-   }
+    override fun endStructure(descriptor: SerialDescriptor) {}
 }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/RootRecordEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/RootRecordEncoder.kt
@@ -3,6 +3,7 @@ package com.github.avrokotlin.avro4k.encoder
 import com.github.avrokotlin.avro4k.Record
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
@@ -22,6 +23,10 @@ class RootRecordEncoder(private val schema: Schema,
          is PolymorphicKind -> UnionEncoder(schema,serializersModule,callback)
          else -> throw SerializationException("Unsupported root element passed to root record encoder")
       }
+   }
+
+   override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
+      super.encodeSerializableValue(serializer, value)
    }
 
    override fun endStructure(descriptor: SerialDescriptor) {

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/UnionEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/UnionEncoder.kt
@@ -5,6 +5,7 @@ import com.github.avrokotlin.avro4k.RecordNaming
 import com.github.avrokotlin.avro4k.schema.DefaultNamingStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.encoding.AbstractEncoder
@@ -32,6 +33,10 @@ class UnionEncoder(private val unionSchema : Schema,
          }
          else -> throw SerializationException("Unsupported root element passed to root record encoder")
       }
+   }
+
+   override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
+      super.encodeSerializableValue(serializer, value)
    }
 
    override fun endStructure(descriptor: SerialDescriptor) {

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/UnionEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/UnionEncoder.kt
@@ -5,7 +5,6 @@ import com.github.avrokotlin.avro4k.RecordNaming
 import com.github.avrokotlin.avro4k.schema.DefaultNamingStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.encoding.AbstractEncoder
@@ -14,32 +13,29 @@ import kotlinx.serialization.modules.SerializersModule
 import org.apache.avro.Schema
 
 @ExperimentalSerializationApi
-class UnionEncoder(private val unionSchema : Schema,
-                   override val serializersModule: SerializersModule,
-                   private val callback: (Record) -> Unit) : AbstractEncoder() {
-   override fun encodeString(value: String){
-      //No need to encode the name of the concrete type. The name will never be encoded in the avro schema.
-   }
-   override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
-      return when (descriptor.kind) {
-         is StructureKind.CLASS, is StructureKind.OBJECT -> {
-            //Hand in the concrete schema for the specified SerialDescriptor so that fields can be correctly decoded.
-            val leafSchema = unionSchema.types.first{
-               val schemaName = RecordNaming(it.fullName, emptyList(), DefaultNamingStrategy)
-               val serialName = RecordNaming(descriptor, DefaultNamingStrategy)
-               serialName == schemaName
+class UnionEncoder(
+    private val unionSchema: Schema,
+    override val serializersModule: SerializersModule,
+    private val callback: (Record) -> Unit
+) : AbstractEncoder() {
+    override fun encodeString(value: String) {
+        //No need to encode the name of the concrete type. The name will never be encoded in the avro schema.
+    }
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
+        return when (descriptor.kind) {
+            is StructureKind.CLASS, is StructureKind.OBJECT -> {
+                //Hand in the concrete schema for the specified SerialDescriptor so that fields can be correctly decoded.
+                val leafSchema = unionSchema.types.first {
+                    val schemaName = RecordNaming(it.fullName, emptyList(), DefaultNamingStrategy)
+                    val serialName = RecordNaming(descriptor, DefaultNamingStrategy)
+                    serialName == schemaName
+                }
+                RecordEncoder(leafSchema, serializersModule, callback)
             }
-            RecordEncoder(leafSchema, serializersModule, callback)
-         }
-         else -> throw SerializationException("Unsupported root element passed to root record encoder")
-      }
-   }
+            else -> throw SerializationException("Unsupported root element passed to root record encoder")
+        }
+    }
 
-   override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
-      super.encodeSerializableValue(serializer, value)
-   }
-
-   override fun endStructure(descriptor: SerialDescriptor) {
-
-   }
+    override fun endStructure(descriptor: SerialDescriptor) {}
 }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/schema/SchemaFor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/schema/SchemaFor.kt
@@ -210,7 +210,7 @@ fun schemaFor(serializersModule: SerializersModule,
    return if (descriptor.isNullable) NullableSchemaFor(schemaFor, annos) else schemaFor
 }
 
-// copy-paste from kotlinx serialization because it internal
+// copy-paste from kotlinx serialization because it is internal
 @ExperimentalSerializationApi
 internal val SerialDescriptor.carrierDescriptor: SerialDescriptor
    get() = if (isInline) getElementDescriptor(0) else this

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/io/MixedPolymorphicIoTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/io/MixedPolymorphicIoTest.kt
@@ -2,6 +2,7 @@ package com.github.avrokotlin.avro4k.io
 
 import com.github.avrokotlin.avro4k.Avro
 import com.github.avrokotlin.avro4k.schema.ConstExpr
+import com.github.avrokotlin.avro4k.schema.Expr
 import com.github.avrokotlin.avro4k.schema.MultiplicationExpr
 import com.github.avrokotlin.avro4k.schema.NegateExpr
 import com.github.avrokotlin.avro4k.schema.OtherBinaryExpr
@@ -22,6 +23,10 @@ class MixedPolymorphicIoTest : StringSpec({
          }
          polymorphic(OtherBinaryExpr::class) {
             subclass(MultiplicationExpr::class)
+         }
+         // this shouldn't be necessary
+         polymorphic(Expr::class) {
+            subclass(NegateExpr::class)
          }
       }
       val avro = Avro(serializersModule = module)

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/io/MixedPolymorphicIoTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/io/MixedPolymorphicIoTest.kt
@@ -29,4 +29,7 @@ class MixedPolymorphicIoTest : StringSpec({
       val toWrite = MixedPolymoprhicIoReference(NegateExpr(3), null, listOf(NegateExpr(1)), mapOf("blub" to NullaryExpr))
       writeRead(toWrite, MixedPolymoprhicIoReference.serializer(), avro)
    }
+   "read / write referencing a subclass implementing a sealed interface" {
+
+   }
 })

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/io/MixedPolymorphicIoTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/io/MixedPolymorphicIoTest.kt
@@ -1,0 +1,35 @@
+package com.github.avrokotlin.avro4k.io
+
+import com.github.avrokotlin.avro4k.Avro
+import com.github.avrokotlin.avro4k.schema.ConstExpr
+import com.github.avrokotlin.avro4k.schema.MultiplicationExpr
+import com.github.avrokotlin.avro4k.schema.NegateExpr
+import com.github.avrokotlin.avro4k.schema.OtherBinaryExpr
+import com.github.avrokotlin.avro4k.schema.OtherUnaryExpr
+import com.github.avrokotlin.avro4k.schema.ReferencingMixedPolymorphic
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import org.apache.avro.generic.GenericRecord
+
+class MixedPolymorphicIoTest : StringSpec({
+   "read / write referencing a mixed sealed hierarchy" {
+      val module = SerializersModule {
+         polymorphic(OtherUnaryExpr::class) {
+            subclass(ConstExpr::class)
+         }
+         polymorphic(OtherBinaryExpr::class) {
+            subclass(MultiplicationExpr::class)
+         }
+      }
+      val avro = Avro(serializersModule = module)
+      writeRead(ReferencingMixedPolymorphic(NegateExpr(3)), ReferencingMixedPolymorphic.serializer(), avro)
+      writeRead(ReferencingMixedPolymorphic(NegateExpr(3)), ReferencingMixedPolymorphic.serializer(), avro) {
+         val reference = it["notNullable"] as GenericRecord
+         reference.schema shouldBe avro.schema(NegateExpr.serializer())
+         reference["value"] shouldBe 3
+      }
+   }
+})

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/io/SealedInterfaceIoTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/io/SealedInterfaceIoTest.kt
@@ -1,0 +1,98 @@
+package com.github.avrokotlin.avro4k.io
+
+import com.github.avrokotlin.avro4k.Avro
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import org.apache.avro.generic.GenericRecord
+import org.apache.avro.util.Utf8
+
+class SealedInterfaceIoTest : StringSpec({
+
+   "read / write sealed interface" {
+
+      writeRead(SealedInterfaceTest(ClassImplSealedInterface("a")), SealedInterfaceTest.serializer())
+      writeRead(SealedInterfaceTest(ClassImplSealedInterface("a")), SealedInterfaceTest.serializer()) {
+         val operation = it["a"] as GenericRecord
+         operation.schema shouldBe Avro.default.schema(ClassImplSealedInterface.serializer())
+         operation["value"] shouldBe Utf8("a")
+      }
+   }
+
+   "read / write sealed interface using object" {
+
+      writeRead(SealedInterfaceTest(ObjectImplSealedInterface), SealedInterfaceTest.serializer())
+      writeRead(SealedInterfaceTest(ObjectImplSealedInterface), SealedInterfaceTest.serializer()) {
+         val operation = it["a"] as GenericRecord
+         operation.schema shouldBe Avro.default.schema(ObjectImplSealedInterface.serializer())
+      }
+   }
+
+   "read / write list of sealed interface values" {
+
+      val test = SealedInterfaceListTest(listOf(
+         ObjectImplSealedInterface,
+         ClassImplSealedInterface("b")
+      ))
+      writeRead(test, SealedInterfaceListTest.serializer())
+      writeRead(test, SealedInterfaceListTest.serializer()) {
+         it["a"].shouldBeInstanceOf<List<GenericRecord>>()
+         @Suppress("UNCHECKED_CAST")
+         val operations = it["a"] as List<GenericRecord>
+         operations.size shouldBe 2
+         operations[0].schema shouldBe Avro.default.schema(ObjectImplSealedInterface.serializer())
+         operations[1].schema shouldBe Avro.default.schema(ClassImplSealedInterface.serializer())
+
+         operations[1]["value"] shouldBe Utf8("b")
+      }
+   }
+
+   "read / write nullable sealed class" {
+      writeRead(NullableSealedInterfaceTest(null), NullableSealedInterfaceTest.serializer())
+      writeRead(NullableSealedInterfaceTest(ObjectImplSealedInterface), NullableSealedInterfaceTest.serializer())
+      writeRead(NullableSealedInterfaceTest(ClassImplSealedInterface("blub")), NullableSealedInterfaceTest.serializer())
+      writeRead(NullableSealedInterfaceTest(ClassImplSealedInterface("blub")), NullableSealedInterfaceTest.serializer()) {
+         val operation = it["a"] as GenericRecord
+         operation.schema shouldBe Avro.default.schema(ClassImplSealedInterface.serializer())
+         operation["value"] shouldBe Utf8("blub")
+      }
+   }
+
+   "read / write mixed hierarchy with sealed interfaces" {
+      val module = SerializersModule {
+         polymorphic(UnsealedInterface::class) {
+            subclass(SealedInterface::class)
+         }
+      }
+      val avro = Avro(serializersModule = module)
+      val toWrite = MixedHierarchySealedInterfaceTest(ClassImplSealedInterface("ba"))
+      writeRead(toWrite,  MixedHierarchySealedInterfaceTest.serializer(), avro)
+   }
+}) {
+
+   interface UnsealedInterface
+
+   sealed interface SealedInterface : UnsealedInterface
+   
+   @Serializable
+   object ObjectImplSealedInterface : SealedInterface
+   
+   @Serializable
+   data class ClassImplSealedInterface (val value : String) : SealedInterface
+
+   @Serializable
+   data class SealedInterfaceTest(val a: SealedInterface)
+
+   @Serializable
+   data class SealedInterfaceListTest(val a: List<SealedInterface>)
+
+   @Serializable
+   data class NullableSealedInterfaceTest(val a: SealedInterface?)
+   
+   @Serializable
+   data class MixedHierarchySealedInterfaceTest(val a : UnsealedInterface)
+}

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/io/SerialNamePolymorphicTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/io/SerialNamePolymorphicTest.kt
@@ -1,0 +1,44 @@
+package com.github.avrokotlin.avro4k.io
+
+import com.github.avrokotlin.avro4k.Avro
+import io.kotest.core.spec.style.StringSpec
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+
+
+class SerialNamePolymorphicTest : StringSpec ({
+  "roundtrip without explicit registration" {
+      writeRead(FooType1, Foo.serializer())
+  }
+    "roundtrip with explicit registration" {
+        val avro = Avro(SerializersModule{
+            polymorphic(Foo::class) {
+                subclass(FooType1::class, FooType1.serializer())
+                subclass(FooType2::class, FooType2.serializer())
+                subclass(FooWithValue::class, FooWithValue.serializer())
+            }
+        })
+        writeRead(FooType1, Foo.serializer(), avro)
+    }
+    "referencing foo" {
+        writeRead(ReferencingFoo(FooType1), ReferencingFoo.serializer())
+    }
+}) {
+
+}
+@Serializable
+sealed class Foo(val type: String)
+
+@Serializable @SerialName("type1")
+object FooType1 : Foo("type1")
+
+@Serializable @SerialName("type2")
+object FooType2 : Foo("type2")
+
+@Serializable @SerialName("withValue")
+data class FooWithValue(val value: Int) : Foo("withValue")
+
+@Serializable
+data class ReferencingFoo(val foo : Foo)

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/MixedPolymorphicSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/MixedPolymorphicSchemaTest.kt
@@ -14,6 +14,7 @@ sealed interface Expr
 sealed interface UnaryExpr : Expr {
     val value : Int
 }
+sealed interface DiamondInheritance : Expr
 @Serializable
 sealed class BinaryExpr : Expr {
     abstract val left: Int
@@ -22,7 +23,7 @@ sealed class BinaryExpr : Expr {
 @Serializable
 object NullaryExpr : Expr
 @Serializable
-data class NegateExpr(override val value : Int) : UnaryExpr
+data class NegateExpr(override val value : Int) : UnaryExpr, DiamondInheritance
 @Serializable
 data class AddExpr(override val left : Int, override val right : Int) : BinaryExpr()
 @Serializable


### PR DESCRIPTION
This should remove the need to explicitly register the subclasses of sealed interfaces. This was demonstrated in PR #113.