### PR TITLE
perf: Build list with initial capacity

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/RecordEncoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/encoder/RecordEncoder.kt
@@ -102,7 +102,7 @@ class RecordEncoder(private val schema: Schema,
 
 class RecordBuilder(private val schema: Schema) {
 
-   private val values = arrayListOf<Any?>()
+   private val values = ArrayList<Any?>(schema.fields.size)
 
    fun add(value: Any?) = values.add(value)
 


### PR DESCRIPTION
It's a very little improvement, but seems  great to prevent allocating 16 items lists while we have 3 fields avro schema 😄 