### PR TITLE
Bump snappy-java version

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -20,7 +20,7 @@ object Libs {
    }
 
    object Xerial {
-      const val snappy = "org.xerial.snappy:snappy-java:1.1.9.1"
+      const val snappy = "org.xerial.snappy:snappy-java:1.1.10.1"
    }
 
    object Avro {


### PR DESCRIPTION
New `snappy-java` version fixes [multiple security vulnerabilities](https://github.com/xerial/snappy-java/releases/tag/v1.1.10.1)
