### PR TITLE
properties with list of values

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/AnnotationExtractor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/AnnotationExtractor.kt
@@ -26,6 +26,7 @@ class AnnotationExtractor(private val annotations: List<Annotation>) {
          annotations.filterIsInstance<AvroAliases>().flatMap { it.value.toList() }
       }
    fun props(): List<Pair<String, String>> = annotations.filterIsInstance<AvroProp>().map { it.key to it.value }
+   fun json(): List<Pair<String, String>> = annotations.filterIsInstance<AvroJsonProp>().map { it.key to it.jsonValue }
    fun default(): String? = annotations.filterIsInstance<AvroDefault>().firstOrNull()?.value
    fun enumDefault(): String? = annotations.filterIsInstance<AvroEnumDefault>().firstOrNull()?.value
 }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/AnnotationExtractor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/AnnotationExtractor.kt
@@ -26,8 +26,7 @@ class AnnotationExtractor(private val annotations: List<Annotation>) {
          annotations.filterIsInstance<AvroAliases>().flatMap { it.value.toList() }
       }
    fun props(): List<Pair<String, String>> = annotations.filterIsInstance<AvroProp>().map { it.key to it.value }
-   fun json(): List<Pair<String, String>> = annotations.filterIsInstance<AvroJsonProp>().map { it.key to it.jsonValue }
+   fun jsonProps(): List<Pair<String, String>> = annotations.filterIsInstance<AvroJsonProp>().map { it.key to it.jsonValue }
    fun default(): String? = annotations.filterIsInstance<AvroDefault>().firstOrNull()?.value
    fun enumDefault(): String? = annotations.filterIsInstance<AvroEnumDefault>().firstOrNull()?.value
 }
-

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
@@ -10,6 +10,10 @@ annotation class AvroProp(val key: String, val value: String)
 
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+annotation class AvroJsonProp(val key: String, val jsonValue: String)
+
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 annotation class AvroNamespace(val value: String)
 
 @SerialInfo

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
@@ -62,7 +62,7 @@ annotation class AvroFixed(val size: Int)
 
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
-annotation class AvroDefault(val value: String)
+annotation class AvroDefault(@Language("json") val value: String)
 
 @SerialInfo
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
@@ -3,6 +3,7 @@ package com.github.avrokotlin.avro4k
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialInfo
+import org.intellij.lang.annotations.Language
 
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
@@ -10,7 +11,7 @@ annotation class AvroProp(val key: String, val value: String)
 
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
-annotation class AvroJsonProp(val key: String, val jsonValue: String)
+annotation class AvroJsonProp(val key: String, @Language("json") val jsonValue: String)
 
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/schema/ClassSchemaFor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/schema/ClassSchemaFor.kt
@@ -67,7 +67,7 @@ class ClassSchemaFor(
       record.fields = fields
       entityAnnotations.aliases().forEach { record.addAlias(it) }
       entityAnnotations.props().forEach { (k, v) -> record.addProp(k, v) }
-      entityAnnotations.json().forEach { (k, v) -> record.addProp(k, json.parseToJsonElement(v).convertToAvroDefault()) }
+      entityAnnotations.jsonProps().forEach { (k, v) -> record.addProp(k, json.parseToJsonElement(v).convertToAvroDefault()) }
 
       return record
    }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/schema/ClassSchemaFor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/schema/ClassSchemaFor.kt
@@ -3,6 +3,7 @@ package com.github.avrokotlin.avro4k.schema
 import com.github.avrokotlin.avro4k.AnnotationExtractor
 import com.github.avrokotlin.avro4k.Avro
 import com.github.avrokotlin.avro4k.AvroConfiguration
+import com.github.avrokotlin.avro4k.AvroJsonProp
 import com.github.avrokotlin.avro4k.AvroProp
 import com.github.avrokotlin.avro4k.RecordNaming
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -66,6 +67,7 @@ class ClassSchemaFor(
       record.fields = fields
       entityAnnotations.aliases().forEach { record.addAlias(it) }
       entityAnnotations.props().forEach { (k, v) -> record.addProp(k, v) }
+      entityAnnotations.json().forEach { (k, v) -> record.addProp(k, json.parseToJsonElement(v).convertToAvroDefault()) }
 
       return record
    }
@@ -122,6 +124,9 @@ class ClassSchemaFor(
       this.descriptor.getElementAnnotations(index)
          .filterIsInstance<AvroProp>()
          .forEach { field.addProp(it.key, it.value) }
+      this.descriptor.getElementAnnotations(index)
+         .filterIsInstance<AvroJsonProp>()
+         .forEach { field.addProp(it.key, json.parseToJsonElement(it.jsonValue).convertToAvroDefault()) }
       annos.aliases().forEach { field.addAlias(it) }
 
       return field

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/AvroJsonPropSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/AvroJsonPropSchemaTest.kt
@@ -46,6 +46,17 @@ class AvroJsonPropSchemaTest : WordSpec() {
    data class AnnotatedProperties(
       @AvroJsonProp("guns", """["and", "roses"]""") val str: String,
       @AvroJsonProp("jean", """["michel", "jarre"]""") val long: Long,
+      @AvroJsonProp(
+         key = "object",
+         jsonValue = """{
+           "a": "foo",
+           "b": 200,
+           "c": true,
+           "d": null,
+           "e": { "e1": null, "e2": 429 },
+           "f": ["bar", 404, false, null, {}]
+         }"""
+      )
       val int: Int
    )
 

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/AvroJsonPropSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/AvroJsonPropSchemaTest.kt
@@ -1,0 +1,54 @@
+package com.github.avrokotlin.avro4k.schema
+
+import com.github.avrokotlin.avro4k.Avro
+import com.github.avrokotlin.avro4k.AvroJsonProp
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+
+class AvroJsonPropSchemaTest : WordSpec() {
+
+   enum class Colours {
+      Red, Green, Blue
+   }
+
+   init {
+      "@AvroJsonProp" should {
+         "support props annotation on class" {
+
+            val expected = org.apache.avro.Schema.Parser()
+               .parse(javaClass.getResourceAsStream("/props_json_annotation_class.json"))
+            val schema = Avro.default.schema(TypeAnnotated.serializer())
+            schema.toString(true) shouldBe expected.toString(true)
+         }
+         "support props annotation on field" {
+
+            val expected = org.apache.avro.Schema.Parser()
+               .parse(javaClass.getResourceAsStream("/props_json_annotation_field.json"))
+            val schema = Avro.default.schema(AnnotatedProperties.serializer())
+            schema.toString(true) shouldBe expected.toString(true)
+         }
+         "support props annotations on enums" {
+
+            val expected = org.apache.avro.Schema.Parser()
+               .parse(javaClass.getResourceAsStream("/props_json_annotation_scala_enum.json"))
+            val schema = Avro.default.schema(EnumAnnotated.serializer())
+            schema.toString(true) shouldBe expected.toString(true)
+         }
+      }
+   }
+
+   @Serializable
+   @AvroJsonProp("guns", """["and", "roses"]""")
+   data class TypeAnnotated(val str: String)
+
+   @Serializable
+   data class AnnotatedProperties(
+      @AvroJsonProp("guns", """["and", "roses"]""") val str: String,
+      @AvroJsonProp("jean", """["michel", "jarre"]""") val long: Long,
+      val int: Int
+   )
+
+   @Serializable
+   data class EnumAnnotated(@AvroJsonProp("guns", """["and", "roses"]""") val colours: Colours)
+}

--- a/src/test/resources/props_json_annotation_class.json
+++ b/src/test/resources/props_json_annotation_class.json
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "TypeAnnotated",
+  "namespace": "com.github.avrokotlin.avro4k.schema.AvroJsonPropSchemaTest",
+  "fields": [
+    {
+      "name": "str",
+      "type": "string"
+    }
+  ],
+   "guns": ["and", "roses"]
+}

--- a/src/test/resources/props_json_annotation_field.json
+++ b/src/test/resources/props_json_annotation_field.json
@@ -15,7 +15,15 @@
     },
     {
       "name": "int",
-      "type": "int"
+      "type": "int",
+      "object": {
+         "a": "foo",
+         "b": 200,
+         "c": true,
+         "d": null,
+         "e": { "e1": null, "e2": 429 },
+         "f": [ "bar", 404, false, null, {} ]
+      }
     }
   ]
 }

--- a/src/test/resources/props_json_annotation_field.json
+++ b/src/test/resources/props_json_annotation_field.json
@@ -1,0 +1,21 @@
+{
+  "type": "record",
+  "name": "AnnotatedProperties",
+  "namespace": "com.github.avrokotlin.avro4k.schema.AvroJsonPropSchemaTest",
+  "fields": [
+    {
+      "name": "str",
+      "type": "string",
+      "guns": ["and", "roses"]
+    },
+    {
+      "name": "long",
+      "type": "long",
+      "jean": ["michel", "jarre"]
+    },
+    {
+      "name": "int",
+      "type": "int"
+    }
+  ]
+}

--- a/src/test/resources/props_json_annotation_scala_enum.json
+++ b/src/test/resources/props_json_annotation_scala_enum.json
@@ -1,0 +1,20 @@
+{
+  "type": "record",
+  "name": "EnumAnnotated",
+  "namespace": "com.github.avrokotlin.avro4k.schema.AvroJsonPropSchemaTest",
+  "fields": [
+    {
+      "name": "colours",
+      "type": {
+        "type": "enum",
+        "name": "Colours",
+        "symbols": [
+          "Red",
+          "Green",
+          "Blue"
+        ]
+      },
+      "guns": ["and", "roses"]
+    }
+  ]
+}


### PR DESCRIPTION
Avro AVSC allows for custom annotations as shown [here](https://issues.apache.org/jira/browse/AVRO-3026).

Same functionality can be partially achieved by using `@AvroProp` annotation, but only for single value annotations. 

For cases - like the linked issue, where a list of values is needed, existing annotation is not enough.

Therefore I'm suggesting adding `@AvropProps("name", "valueA", "valueB", "etc")`