### PR TITLE
feat(aliases): Merge AvroAliases annotation to AvroAlias

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
 tasks.withType<KotlinCompile>().configureEach {
    kotlinOptions.jvmTarget = "1.8"
    kotlinOptions.apiVersion = "1.5"
-   kotlinOptions.languageVersion = "1.5"   
+   kotlinOptions.languageVersion = "1.5"
    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
 }
 java {

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/AnnotationExtractor.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/AnnotationExtractor.kt
@@ -2,6 +2,7 @@ package com.github.avrokotlin.avro4k
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.descriptors.SerialDescriptor
+
 @ExperimentalSerializationApi
 class AnnotationExtractor(private val annotations: List<Annotation>) {
 
@@ -19,12 +20,7 @@ class AnnotationExtractor(private val annotations: List<Annotation>) {
    fun name(): String? = annotations.filterIsInstance<AvroName>().firstOrNull()?.value
    fun valueType(): Boolean = annotations.filterIsInstance<AvroInline>().isNotEmpty()
    fun doc(): String? = annotations.filterIsInstance<AvroDoc>().firstOrNull()?.value
-   fun aliases(): List<String> =
-      if(annotations.any { it is AvroAlias }){
-         annotations.filterIsInstance<AvroAlias>().map { it.value }
-      }else{
-         annotations.filterIsInstance<AvroAliases>().flatMap { it.value.toList() }
-      }
+   fun aliases(): List<String> = (annotations.firstNotNullOfOrNull { it as? AvroAlias }?.value ?: emptyArray()).asList() + (annotations.firstNotNullOfOrNull {it as? AvroAliases}?.value ?: emptyArray())
    fun props(): List<Pair<String, String>> = annotations.filterIsInstance<AvroProp>().map { it.key to it.value }
    fun jsonProps(): List<Pair<String, String>> = annotations.filterIsInstance<AvroJsonProp>().map { it.key to it.jsonValue }
    fun default(): String? = annotations.filterIsInstance<AvroDefault>().firstOrNull()?.value

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
@@ -35,9 +35,10 @@ annotation class AvroDoc(val value: String)
 
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
-annotation class AvroAlias(val value: String)
+annotation class AvroAlias(vararg val value: String)
 
 @SerialInfo
+@Deprecated(message = "Will be removed in the next major release", replaceWith = ReplaceWith("@AvroAlias(alias1, alias2)"))
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 annotation class AvroAliases(val value: Array<String>)
 

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/AvroAliasSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/AvroAliasSchemaTest.kt
@@ -2,9 +2,8 @@ package com.github.avrokotlin.avro4k.schema
 
 import com.github.avrokotlin.avro4k.Avro
 import com.github.avrokotlin.avro4k.AvroAlias
-import com.github.avrokotlin.avro4k.AvroAliases
-import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 
 class AvroAliasSchemaTest : WordSpec({
@@ -41,7 +40,7 @@ class AvroAliasSchemaTest : WordSpec({
     @AvroAlias("queen")
     data class TypeAnnotated(val str: String)
 
-    @AvroAliases(["queen","ledzep"])
+    @AvroAlias("queen", "ledzep")
     @Serializable
     data class TypeAliasAnnotated(val str: String)
 
@@ -49,5 +48,5 @@ class AvroAliasSchemaTest : WordSpec({
     data class FieldAnnotated(@AvroAlias("cold") val str: String, @AvroAlias("kate") val long: Long, val int: Int)
 
     @Serializable
-    data class FieldAliasAnnotated(@AvroAliases(["queen","ledzep"]) val str: String)
+    data class FieldAliasAnnotated(@AvroAlias("queen", "ledzep") val str: String)
 }

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/EnumSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/EnumSchemaTest.kt
@@ -1,7 +1,7 @@
 package com.github.avrokotlin.avro4k.schema
 
 import com.github.avrokotlin.avro4k.Avro
-import com.github.avrokotlin.avro4k.AvroAliases
+import com.github.avrokotlin.avro4k.AvroAlias
 import com.github.avrokotlin.avro4k.AvroDefault
 import com.github.avrokotlin.avro4k.AvroDoc
 import com.github.avrokotlin.avro4k.AvroEnumDefault
@@ -89,7 +89,7 @@ enum class Wine {
 }
 
 @Serializable
-@AvroAliases(["MySuit"])
+@AvroAlias("MySuit")
 @AvroDoc("documentation")
 enum class Suit {
    SPADES, HEARTS, DIAMONDS, CLUBS;


### PR DESCRIPTION
- Now, to have multiple aliases, just annotate like `@AvroAlias("alias1", "alias2", "alias3")` as it is now a vararg parameter
- updated to kotlin 1.9 to have `@Repeatable` working
- deprecated `@AvroAliases` in favor of `@AvroAlias`
- Closes #155