### PR TITLE
fix(annotations): Set the `@Language` value to `JSON`

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
@@ -11,7 +11,7 @@ annotation class AvroProp(val key: String, val value: String)
 
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
-annotation class AvroJsonProp(val key: String, @Language("json") val jsonValue: String)
+annotation class AvroJsonProp(val key: String, @Language("JSON") val jsonValue: String)
 
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
@@ -62,7 +62,7 @@ annotation class AvroFixed(val size: Int)
 
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
-annotation class AvroDefault(@Language("json") val value: String)
+annotation class AvroDefault(@Language("JSON") val value: String)
 
 @SerialInfo
 @Target(AnnotationTarget.CLASS)


### PR DESCRIPTION
tested `AvroJsonProp` on my computer and the json language injection is not working. After a quick check, tldr: replace `@Language("json")` by `@Language("JSON")`.
Longer story: language injection is done by intellij, and we can find all the languages in `Parameters > Editor > Language injections`. We should set a value found inside the `Language` column, where we can only find `JSON` and not `json`, maybe it's case sensitive!

If still not working, let's remove the annotation then!