### PR TITLE
Added support for decoding with avro alias

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/FieldNaming.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/FieldNaming.kt
@@ -21,4 +21,11 @@ class FieldNaming(private val name: String, annotations: List<Annotation>) {
     *  Takes into account @AvroName.
     */
    fun name(): String = extractor.name() ?: name
+
+
+   /**
+    *  Returns the avro aliases for the current element.
+    *  Takes into account @AvroAlias.
+    */
+   fun aliases(): List<String> = extractor.aliases()
 }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/RecordDecoder.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/decoder/RecordDecoder.kt
@@ -85,6 +85,13 @@ class RecordDecoder(
         if (record.hasField(resolvedFieldName())) {
             return record.get(resolvedFieldName())
         }
+
+        FieldNaming(desc, currentIndex).aliases().forEach {
+           if (record.hasField(it)) {
+              return record.get(it)
+           }
+        }
+
         return null
     }
 

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/decoder/AvroAliasTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/decoder/AvroAliasTest.kt
@@ -1,0 +1,23 @@
+package com.github.avrokotlin.avro4k.decoder
+
+import com.github.avrokotlin.avro4k.Avro
+import com.github.avrokotlin.avro4k.AvroAlias
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import org.apache.avro.generic.GenericData
+
+@Serializable
+data class OldFooString(val s: String)
+@Serializable
+data class FooStringWithAlias(@AvroAlias("s") val str: String)
+
+class AvroAliasTest : FunSpec({
+
+   test("decode with alias") {
+      val schema = Avro.default.schema(OldFooString.serializer())
+      val record = GenericData.Record(schema)
+      record.put("s", "hello")
+      Avro.default.fromRecord(FooStringWithAlias.serializer(), record) shouldBe FooStringWithAlias("hello")
+   }
+})


### PR DESCRIPTION
Problem: We want to read some data using Avro evolution mechanism for field renaming. Current behavior does not account for AvroAlias annotation.

Proposed solution: fieldValue() function iterates through list of possible field names, starting with the resolvedFieldName. For each attempt, if record contains the field name, return the value returned from record.get(...), else continue.

Closes #170