### PR TITLE
feat: Merge ScalePrecision to AvroDecimalLogicalType

### DIFF
--- a/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/annotations.kt
@@ -2,6 +2,7 @@
 
 package com.github.avrokotlin.avro4k
 
+import com.github.avrokotlin.avro4k.serializer.BigDecimalSerializer
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialInfo
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -28,20 +29,23 @@ annotation class AvroJsonProp(
     @Language("JSON") val jsonValue: String,
 )
 
+/**
+ * To be used with [BigDecimalSerializer] to specify the scale, precision, type and rounding mode of the decimal value.
+ */
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY)
-annotation class ScalePrecision(val scale: Int = 2, val precision: Int = 8)
-
-@SerialInfo
-@Target(AnnotationTarget.PROPERTY)
-annotation class AvroDecimalLogicalType(val schema: LogicalDecimalTypeEnum = LogicalDecimalTypeEnum.BYTES)
+annotation class AvroDecimalLogicalType(
+    val scale: Int = 2,
+    val precision: Int = 8,
+    val schema: LogicalDecimalTypeEnum = LogicalDecimalTypeEnum.BYTES,
+)
 
 enum class LogicalDecimalTypeEnum {
     BYTES,
     STRING,
 
     /**
-     * Fixed must be accompanied with [AvroFixed]
+     * Fixed requires the field annotated with [AvroFixed]
      */
     FIXED,
 }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/serializer/BigDecimalSerializer.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/serializer/BigDecimalSerializer.kt
@@ -1,38 +1,28 @@
 package com.github.avrokotlin.avro4k.serializer
 
 import com.github.avrokotlin.avro4k.AvroDecimalLogicalType
-import com.github.avrokotlin.avro4k.ScalePrecision
 import com.github.avrokotlin.avro4k.decoder.ExtendedDecoder
 import com.github.avrokotlin.avro4k.encoder.ExtendedEncoder
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.descriptors.buildSerialDescriptor
 import org.apache.avro.Conversions
 import org.apache.avro.LogicalTypes
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericFixed
-import org.apache.avro.util.Utf8
 import java.math.BigDecimal
-import java.math.RoundingMode
 import java.nio.ByteBuffer
 
 @OptIn(ExperimentalSerializationApi::class)
-@Serializer(forClass = BigDecimal::class)
 class BigDecimalSerializer : AvroSerializer<BigDecimal>() {
-    private val defaultScalePrecision = ScalePrecision()
-    private val defaultLogicalDecimal = AvroDecimalLogicalType()
+    private val converter = Conversions.DecimalConversion()
 
     @OptIn(InternalSerializationApi::class)
     override val descriptor =
         buildSerialDescriptor(BigDecimal::class.qualifiedName!!, StructureKind.OBJECT) {
-            annotations =
-                listOf(
-                    defaultScalePrecision,
-                    defaultLogicalDecimal
-                )
+            annotations = listOf(AvroDecimalLogicalType())
         }
 
     override fun encodeAvroValue(
@@ -43,37 +33,22 @@ class BigDecimalSerializer : AvroSerializer<BigDecimal>() {
         // we support encoding big decimals in three ways - fixed, bytes or as a String, depending on the schema passed in
         // the scale and precision should come from the schema and the rounding mode from the implicit
 
-        val converter = Conversions.DecimalConversion()
-        val rm = RoundingMode.UNNECESSARY
-
         return when (schema.type) {
             Schema.Type.STRING -> encoder.encodeString(obj.toString())
             Schema.Type.BYTES -> {
                 when (val logical = schema.logicalType) {
-                    is LogicalTypes.Decimal ->
-                        encoder.encodeByteArray(
-                            converter.toBytes(
-                                obj.setScale(logical.scale, rm),
-                                schema,
-                                logical
-                            )
-                        )
+                    is LogicalTypes.Decimal -> encoder.encodeByteArray(converter.toBytes(obj, schema, logical))
                     else -> throw SerializationException("Cannot encode BigDecimal to FIXED for logical type $logical")
                 }
             }
+
             Schema.Type.FIXED -> {
                 when (val logical = schema.logicalType) {
-                    is LogicalTypes.Decimal ->
-                        encoder.encodeFixed(
-                            converter.toFixed(
-                                obj.setScale(logical.scale, rm),
-                                schema,
-                                logical
-                            )
-                        )
+                    is LogicalTypes.Decimal -> encoder.encodeFixed(converter.toFixed(obj, schema, logical))
                     else -> throw SerializationException("Cannot encode BigDecimal to FIXED for logical type $logical")
                 }
             }
+
             else -> throw SerializationException("Cannot encode BigDecimal as ${schema.type}")
         }
     }
@@ -89,10 +64,10 @@ class BigDecimalSerializer : AvroSerializer<BigDecimal>() {
             }
 
         return when (val v = decoder.decodeAny()) {
-            is Utf8 -> BigDecimal(decoder.decodeString())
-            is ByteArray -> Conversions.DecimalConversion().fromBytes(ByteBuffer.wrap(v), schema, logical())
-            is ByteBuffer -> Conversions.DecimalConversion().fromBytes(v, schema, logical())
-            is GenericFixed -> Conversions.DecimalConversion().fromFixed(v, schema, logical())
+            is CharSequence -> BigDecimal(v.toString())
+            is ByteArray -> converter.fromBytes(ByteBuffer.wrap(v), schema, logical())
+            is ByteBuffer -> converter.fromBytes(v, schema, logical())
+            is GenericFixed -> converter.fromFixed(v, schema, logical())
             else -> throw SerializationException("Unsupported BigDecimal type [$v]")
         }
     }

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/decoder/AvroDefaultValuesDecoderTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/decoder/AvroDefaultValuesDecoderTest.kt
@@ -1,9 +1,9 @@
 package com.github.avrokotlin.avro4k.decoder
 
 import com.github.avrokotlin.avro4k.Avro
+import com.github.avrokotlin.avro4k.AvroDecimalLogicalType
 import com.github.avrokotlin.avro4k.AvroDefault
 import com.github.avrokotlin.avro4k.AvroEnumDefault
-import com.github.avrokotlin.avro4k.ScalePrecision
 import com.github.avrokotlin.avro4k.io.AvroDecodeFormat
 import com.github.avrokotlin.avro4k.serializer.BigDecimalSerializer
 import io.kotest.core.spec.style.FunSpec
@@ -49,7 +49,7 @@ data class ContainerWithDefaultFields(
     @AvroDefault("""[{"content":"bar"}]""")
     val filledFooList: List<FooElement>,
     @AvroDefault("\u0000")
-    @ScalePrecision(0, 10)
+    @AvroDecimalLogicalType(0, 10)
     @Serializable(BigDecimalSerializer::class)
     val bigDecimal: BigDecimal,
 )

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/BigDecimalSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/BigDecimalSchemaTest.kt
@@ -3,7 +3,7 @@
 package com.github.avrokotlin.avro4k.schema
 
 import com.github.avrokotlin.avro4k.Avro
-import com.github.avrokotlin.avro4k.ScalePrecision
+import com.github.avrokotlin.avro4k.AvroDecimalLogicalType
 import com.github.avrokotlin.avro4k.serializer.BigDecimalSerializer
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -37,7 +37,7 @@ class BigDecimalSchemaTest : FunSpec({
 
     @Serializable
     data class BigDecimalPrecisionTest(
-        @ScalePrecision(1, 4) val decimal: BigDecimal,
+        @AvroDecimalLogicalType(1, 4) val decimal: BigDecimal,
     )
 
     @Serializable


### PR DESCRIPTION
# Breaking change
- `ScalePrecision` annotation is removed, as `scale` and `precision` params moved to `AvroDecimalLogicalType` (Closes #189) 