### PR TITLE
chore: Use WeakHashMap instead of buggy WeakIdentityHashMap

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -26,34 +26,34 @@ Computer: Macbook air M2
 
 ```
 Benchmark                                                       Mode   Cnt     Score       Error   Units
-c.g.a.b.complex.Avro4kBenchmark.read                            thrpt    5  27070.886 ±  2562.606  ops/s
-c.g.a.b.complex.ApacheAvroReflectBenchmark.read                 thrpt    5  26239.615 ± 15033.290  ops/s
-c.g.a.b.complex.Avro4kGenericWithApacheAvroBenchmark.read       thrpt    5  16140.138 ±    90.523  ops/s
+ApacheAvroReflectBenchmark.read            thrpt    5  28819.641 ± 1048.236  ops/s
+Avro4kBenchmark.read                       thrpt    5  27259.164 ±  418.829  ops/s
+Avro4kGenericWithApacheAvroBenchmark.read  thrpt    5  16242.380 ±  123.109  ops/s
 
-c.g.a.b.complex.Avro4kBenchmark.write                           thrpt    5  54488.317 ±  719.412   ops/s
-c.g.a.b.complex.ApacheAvroReflectBenchmark.write                thrpt    5  47510.885 ± 2467.348   ops/s
-c.g.a.b.complex.JacksonAvroBenchmark.write                      thrpt    5  33936.765 ± 2139.528   ops/s
-c.g.a.b.complex.Avro4kGenericWithApacheAvroBenchmark.write      thrpt    5  24072.277 ±  697.493   ops/s
+Avro4kBenchmark.write                       thrpt    5  55760.544 ±  394.596  ops/s
+ApacheAvroReflectBenchmark.write            thrpt    5  48015.770 ± 4021.317  ops/s
+JacksonAvroBenchmark.write                  thrpt    5  34701.945 ±  719.865  ops/s
+Avro4kGenericWithApacheAvroBenchmark.write  thrpt    5  23859.446 ± 3207.023  ops/s
 
-c.g.a.b.simple.Avro4kSimpleBenchmark.read                       thrpt    5  221277.895 ±  3945.928  ops/s
-c.g.a.b.simple.ApacheAvroReflectSimpleBenchmark.read            thrpt    5  230744.377 ± 30164.628  ops/s
-c.g.a.b.simple.Avro4kGenericWithApacheAvroSimpleBenchmark.read  thrpt    5  138394.796 ±  5130.421  ops/s
-c.g.a.b.simple.JacksonAvroSimpleBenchmark.read                  thrpt    5   69615.099 ±  4047.717  ops/s
+Avro4kSimpleBenchmark.read                       thrpt    5  224766.920 ± 21004.000  ops/s
+ApacheAvroReflectSimpleBenchmark.read            thrpt    5  214986.578 ± 23138.102  ops/s
+Avro4kGenericWithApacheAvroSimpleBenchmark.read  thrpt    5  146503.504 ±  2613.945  ops/s
+JacksonAvroSimpleBenchmark.read                  thrpt    5   66071.428 ±  1571.426  ops/s
 
-c.g.a.b.simple.Avro4kSimpleBenchmark.write                      thrpt    5  446673.090 ± 15520.264  ops/s
-c.g.a.b.simple.ApacheAvroReflectSimpleBenchmark.write           thrpt    5  320367.673 ± 33394.537  ops/s
-c.g.a.b.simple.Avro4kGenericWithApacheAvroSimpleBenchmark.write thrpt    5  168702.542 ±  5553.797  ops/s
-c.g.a.b.simple.JacksonAvroSimpleBenchmark.write                 thrpt    5  138898.312 ±  9156.715  ops/s
+Avro4kSimpleBenchmark.write                       thrpt    5  448433.701 ±  2086.119  ops/s
+ApacheAvroReflectSimpleBenchmark.write            thrpt    5  245640.080 ±  3835.344  ops/s
+Avro4kGenericWithApacheAvroSimpleBenchmark.write  thrpt    5  158308.148 ± 12314.688  ops/s
+JacksonAvroSimpleBenchmark.write                  thrpt    5  125374.072 ±  5240.116  ops/s
 
-JacksonAvroListsBenchmark.read                  thrpt    5  7.441 ± 1.575  ops/s
-Avro4kListsBenchmark.read                       thrpt    5  6.443 ± 1.822  ops/s
-Avro4kGenericWithApacheAvroListsBenchmark.read  thrpt    5  5.166 ± 0.120  ops/s
-ApacheAvroReflectListsBenchmark.read            thrpt    5  4.461 ± 0.520  ops/s
+JacksonAvroListsBenchmark.read                  thrpt    5  6.329 ± 0.631  ops/s
+Avro4kListsBenchmark.read                       thrpt    5  5.074 ± 1.624  ops/s
+ApacheAvroReflectListsBenchmark.read            thrpt    5  4.048 ± 0.366  ops/s
+Avro4kGenericWithApacheAvroListsBenchmark.read  thrpt    5  3.709 ± 1.694  ops/s
 
-ApacheAvroReflectListsBenchmark.write            thrpt    5  7.199 ± 1.409  ops/s
-Avro4kListsBenchmark.write                       thrpt    5  6.140 ± 0.200  ops/s
-JacksonAvroListsBenchmark.write                  thrpt    5  5.247 ± 0.258  ops/s
-Avro4kGenericWithApacheAvroListsBenchmark.write  thrpt    5  4.520 ± 1.391  ops/s
+ApacheAvroReflectListsBenchmark.write            thrpt    5  7.332 ± 0.532  ops/s
+Avro4kListsBenchmark.write                       thrpt    5  6.074 ± 0.087  ops/s
+JacksonAvroListsBenchmark.write                  thrpt    5  3.590 ± 1.973  ops/s
+Avro4kGenericWithApacheAvroListsBenchmark.write  thrpt    5  3.406 ± 0.900  ops/s
 
 ```
 

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-avro:$jacksonVersion")
+    implementation("org.slf4j:slf4j-simple:2.0.17")
 
     implementation(project(":"))
 }

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/Avro.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/Avro.kt
@@ -22,7 +22,7 @@ import kotlinx.serialization.serializer
 import okio.Buffer
 import org.apache.avro.Schema
 import org.apache.avro.io.DecoderFactory
-import org.apache.avro.util.WeakIdentityHashMap
+import java.util.WeakHashMap
 
 /**
  * The goal of this class is to serialize and deserialize in avro binary format, not in GenericRecords.
@@ -31,10 +31,7 @@ public sealed class Avro(
     public val configuration: AvroConfiguration,
     public final override val serializersModule: SerializersModule,
 ) : BinaryFormat {
-    // We use the identity hash map because we could have multiple descriptors with the same name, especially
-    // when having 2 different version of the schema for the same name. kotlinx-serialization is instantiating the descriptors
-    // only once, so we are safe in the main use cases. Combined with weak references to avoid memory leaks.
-    private val schemaCache: MutableMap<SerialDescriptor, Schema> = WeakIdentityHashMap()
+    private val schemaCache: MutableMap<SerialDescriptor, Schema> = WeakHashMap()
 
     internal val recordResolver = RecordResolver(this)
     internal val polymorphicResolver = PolymorphicResolver(serializersModule)

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/internal/EnumResolver.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/internal/EnumResolver.kt
@@ -2,10 +2,10 @@ package com.github.avrokotlin.avro4k.internal
 
 import com.github.avrokotlin.avro4k.AvroEnumDefault
 import kotlinx.serialization.descriptors.SerialDescriptor
-import org.apache.avro.util.WeakIdentityHashMap
+import java.util.WeakHashMap
 
 internal class EnumResolver {
-    private val defaultIndexCache: MutableMap<SerialDescriptor, EnumDefault> = WeakIdentityHashMap()
+    private val defaultIndexCache: MutableMap<SerialDescriptor, EnumDefault> = WeakHashMap()
 
     private data class EnumDefault(val index: Int?)
 

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/internal/PolymorphicResolver.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/internal/PolymorphicResolver.kt
@@ -3,10 +3,10 @@ package com.github.avrokotlin.avro4k.internal
 import com.github.avrokotlin.avro4k.AvroAlias
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.modules.SerializersModule
-import org.apache.avro.util.WeakIdentityHashMap
+import java.util.WeakHashMap
 
 internal class PolymorphicResolver(private val serializersModule: SerializersModule) {
-    private val cache = WeakIdentityHashMap<SerialDescriptor, Map<String, String>>()
+    private val cache = WeakHashMap<SerialDescriptor, Map<String, String>>()
 
     fun getFullNamesAndAliasesToSerialName(descriptor: SerialDescriptor): Map<String, String> {
         return cache.getOrPut(descriptor) {

--- a/src/main/kotlin/com/github/avrokotlin/avro4k/internal/RecordResolver.kt
+++ b/src/main/kotlin/com/github/avrokotlin/avro4k/internal/RecordResolver.kt
@@ -21,7 +21,6 @@ import kotlinx.serialization.json.int
 import kotlinx.serialization.json.long
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
-import org.apache.avro.util.WeakIdentityHashMap
 import java.util.WeakHashMap
 
 internal class RecordResolver(
@@ -32,7 +31,7 @@ internal class RecordResolver(
      *
      * Note: We use the descriptor in the key as we could have multiple descriptors for the same record schema, and multiple record schemas for the same descriptor.
      */
-    private val fieldCache: MutableMap<SerialDescriptor, MutableMap<Schema, SerializationWorkflow>> = WeakIdentityHashMap()
+    private val fieldCache: MutableMap<Pair<SerialDescriptor, Schema>, SerializationWorkflow> = WeakHashMap()
 
     /**
      * Maps the class fields to the schema fields.
@@ -53,7 +52,7 @@ internal class RecordResolver(
         if (classDescriptor.elementsCount == 0 && writerSchema.fields.isEmpty()) {
             return SerializationWorkflow.EMPTY
         }
-        return fieldCache.getOrPut(classDescriptor) { WeakHashMap() }.getOrPut(writerSchema) {
+        return fieldCache.getOrPut(classDescriptor to writerSchema) {
             loadCache(classDescriptor, writerSchema)
         }
     }

--- a/src/test/kotlin/com/github/avrokotlin/avro4k/encoding/AvroFixedEncodingTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/encoding/AvroFixedEncodingTest.kt
@@ -126,7 +126,7 @@ internal class AvroFixedEncodingTest : StringSpec({
     )
 
     @Serializable
-    @SerialName("Fixed")
+    @SerialName("FieldPriorToValueClass")
     private data class FieldPriorToValueClass(
         @AvroFixed(5) val mystring: FixedStringValueClass,
     )

--- a/src/test/resources/fixed_string_5.json
+++ b/src/test/resources/fixed_string_5.json
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "name": "Fixed",
+  "name": "FieldPriorToValueClass",
   "fields": [
     {
       "name": "mystring",


### PR DESCRIPTION
Solves an issue of performance where WeakIdentityHashMap uses too early a synchronised block. Closes #303