### PR TITLE
feat(core): Allow specifying sync marker for byte deterministic output

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,16 @@ fun main() {
 
 </details>
 
+The writer builder also allows customizing the file `codec`, `syncInterval`, `metadata`, and the block `syncMarker`.
+By default a random 16-byte sync marker is generated per file, so encoding the same data twice produces different bytes.
+Pass a fixed `syncMarker` to get byte-for-byte deterministic output (useful for tests or content-addressed storage):
+
+```kotlin
+AvroObjectContainer.openWriter(fileStream) {
+    syncMarker(ByteArray(16) { 0 })
+}.use { writer -> /* ... */ }
+```
+
 > For more details, see the Avro spec on [object container files](https://avro.apache.org/docs/1.12.1/specification/#object-container-files).
 
 # Important notes

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -185,6 +185,7 @@ public final class com/github/avrokotlin/avro4k/AvroObjectContainerBuilder {
 	public final fun metadata (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun metadata (Ljava/lang/String;[B)V
 	public final fun syncInterval (I)V
+	public final fun syncMarker ([B)V
 }
 
 public final class com/github/avrokotlin/avro4k/AvroObjectContainerKt {

--- a/core/src/main/kotlin/com/github/avrokotlin/avro4k/AvroObjectContainer.kt
+++ b/core/src/main/kotlin/com/github/avrokotlin/avro4k/AvroObjectContainer.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.serializer
 import org.apache.avro.Schema
 import org.apache.avro.file.CodecFactory
+import org.apache.avro.file.DataFileConstants
 import org.apache.avro.file.DataFileStream
 import org.apache.avro.file.DataFileWriter
 import org.apache.avro.io.DatumReader
@@ -40,8 +41,14 @@ public sealed class AvroObjectContainer(
     ): AvroObjectContainerWriter<T> {
         val datumWriter: DatumWriter<T> = KotlinxSerializationDatumWriter(serializer, avro)
         val dataFileWriter = DataFileWriter(datumWriter)
-        builder(AvroObjectContainerBuilder(dataFileWriter))
-        dataFileWriter.create(schema, outputStream)
+        val containerBuilder = AvroObjectContainerBuilder(dataFileWriter)
+        builder(containerBuilder)
+        val syncMarker = containerBuilder.syncMarker
+        if (syncMarker != null) {
+            dataFileWriter.create(schema, outputStream, syncMarker)
+        } else {
+            dataFileWriter.create(schema, outputStream)
+        }
         return AvroObjectContainerWriter(dataFileWriter)
     }
 
@@ -102,6 +109,20 @@ public inline fun <reified T> AvroObjectContainer.decodeFromStream(
 
 @ExperimentalAvro4kApi
 public class AvroObjectContainerBuilder internal constructor(private val fileWriter: DataFileWriter<*>) {
+    internal var syncMarker: ByteArray? = null
+        private set
+
+    /**
+     * Fixes the 16-byte block sync marker instead of generating a random one, making the output byte-for-byte deterministic.
+     * Prefer a random-looking value so readers can still resynchronize within a stream.
+     */
+    public fun syncMarker(value: ByteArray) {
+        require(value.size == DataFileConstants.SYNC_SIZE) {
+            "sync marker must be exactly ${DataFileConstants.SYNC_SIZE} bytes, got ${value.size}"
+        }
+        syncMarker = value.copyOf()
+    }
+
     public fun metadata(
         key: String,
         value: ByteArray,

--- a/core/src/test/kotlin/com/github/avrokotlin/avro4k/AvroObjectContainerTest.kt
+++ b/core/src/test/kotlin/com/github/avrokotlin/avro4k/AvroObjectContainerTest.kt
@@ -121,6 +121,48 @@ internal class AvroObjectContainerTest : StringSpec({
         writer.close()
         os.closed shouldBe false
     }
+    "a fixed sync marker produces byte-for-byte deterministic output" {
+        val syncMarker = ByteArray(16) { it.toByte() }
+
+        fun encode() =
+            ByteArrayOutputStream().use {
+                val writer =
+                    AvroObjectContainer.openWriter<UserProfile>(it) {
+                        syncMarker(syncMarker)
+                    }
+                writer.writeValue(firstProfile)
+                writer.writeValue(secondProfile)
+                writer.close()
+                it.toByteArray()
+            }
+
+        encode() shouldBe encode()
+
+        // random marker (the default) is not deterministic
+        fun encodeRandom() =
+            ByteArrayOutputStream().use {
+                val writer = AvroObjectContainer.openWriter<UserProfile>(it)
+                writer.writeValue(firstProfile)
+                writer.close()
+                it.toByteArray()
+            }
+        (encodeRandom() contentEquals encodeRandom()) shouldBe false
+
+        val dataFile =
+            DataFileStream<GenericRecord>(encode().inputStream(), GenericDatumReader(Avro.schema<UserProfile>()))
+        normalizeGenericData(dataFile.next()) shouldBe firstProfileGenericData
+        normalizeGenericData(dataFile.next()) shouldBe secondProfileGenericData
+        dataFile.hasNext() shouldBe false
+    }
+    "an invalid sync marker length is rejected" {
+        shouldThrow<IllegalArgumentException> {
+            ByteArrayOutputStream().use {
+                AvroObjectContainer.openWriter<UserProfile>(it) {
+                    syncMarker(ByteArray(8))
+                }
+            }
+        }
+    }
     "decoding error is not closing the stream" {
         class SimpleInputStream : InputStream() {
             var closed = false


### PR DESCRIPTION
Resolves https://github.com/avro-kotlin/avro4k/issues/83, see justification at https://github.com/avro-kotlin/avro4k/issues/83#issuecomment-5554479089.

This PR allows providing a sync marker in order to provide byte deterministic output of avro files.

A test has been written to confirm that everything works as expected.